### PR TITLE
Cast or op

### DIFF
--- a/lib/PPI/Token/Unknown.pm
+++ b/lib/PPI/Token/Unknown.pm
@@ -82,7 +82,7 @@ sub __TOKENIZER__on_char {
 			return 1;
 		}
 
-		return $self->_as_cast_or_op($t) if $self->_is_cast_or_op($char);
+		return $self->_as_cast_or_op($t) if __is_cast_or_op($char);
 
 		$t->{class} = $t->{token}->set_class( 'Operator' );
 		return $t->_finalize_token->__TOKENIZER__on_char( $t );
@@ -171,13 +171,13 @@ sub __TOKENIZER__on_char {
 			# Get rest of line
 			pos $t->{line} = $t->{line_cursor} + 1;
 			if ( $t->{line} =~ m/$CURLY_SYMBOL/gc ) {
-				# control-character symbol (e.g. @{^_Foo})
+				# control-character symbol (e.g. %{^_Foo})
 				$t->{class} = $t->{token}->set_class( 'Magic' );
 				return 1;
 			}
 		}
 
-		return $self->_as_cast_or_op($t) if $self->_is_cast_or_op($char);
+		return $self->_as_cast_or_op($t) if __is_cast_or_op($char);
 
 		# Probably the mod operator
 		$t->{class} = $t->{token}->set_class( 'Operator' );
@@ -199,7 +199,7 @@ sub __TOKENIZER__on_char {
 			return 1;
 		}
 
-		return $self->_as_cast_or_op($t) if $self->_is_cast_or_op($char);
+		return $self->_as_cast_or_op($t) if __is_cast_or_op($char);
 
 		# Probably the binary and operator
 		$t->{class} = $t->{token}->set_class( 'Operator' );
@@ -257,8 +257,8 @@ sub __TOKENIZER__on_char {
 	PPI::Exception->throw('Unknown value in PPI::Token::Unknown token');
 }
 
-sub _is_cast_or_op {
-	my ( $self, $char ) = @_;
+sub __is_cast_or_op {
+	my ( $char ) = @_;
 	return 1 if $char eq '$';
 	return 1 if $char eq '@';
 	return 1 if $char eq '%';
@@ -269,31 +269,87 @@ sub _is_cast_or_op {
 
 sub _as_cast_or_op {
 	my ( $self, $t ) = @_;
-	my $class = $self->_cast_or_op( $t );
+	my $class = _cast_or_op( $t );
 	$t->{class} = $t->{token}->set_class( $class );
 	return $t->_finalize_token->__TOKENIZER__on_char( $t );
 }
 
 # Operator/operand-sensitive, multiple or GLOB cast
 sub _cast_or_op {
-	my ( undef, $t ) = @_;
-	my ( $prev ) = @{ $t->_previous_significant_tokens(1) };
-	return 'Cast' if !$prev;
+	my ( $t ) = @_;
 
-	return 'Operator' if
-		$prev->isa('PPI::Token::Symbol')
-		or
-		$prev->isa('PPI::Token::Number')
-		or
-		(
-			$prev->isa('PPI::Token::Structure')
-			and
-			$prev->content =~ /^(?:\)|\]|\})$/
-		);
+	my $tokens = $t->{tokens};
+	my $cursor = scalar(@$tokens)-1;
+	my $token;
 
-	# This is pretty weak, there's room for a dozen more tests before going with
-	# a default. Or even better, a proper operator/operand method :(
-	return 'Cast';
+	while ( $cursor >= 0 ) {
+		$token = $tokens->[$cursor--];
+		last if $token->significant;
+	}
+	return 'Cast' if !$token;  # token was first in the document
+
+	if ( $token->isa('PPI::Token::Structure') ) {
+		if ( $token->content eq '}' ) {
+			# Scan the token stream backwards an arbitrarily long way,
+			# looking for the matching opening curly brace.
+			my $structure_depth = 1;
+
+			$token = undef;
+			while ( $cursor >= 0 ) {
+				$token = $tokens->[$cursor--];
+				next if !$token->significant;
+				next if !$token->isa( 'PPI::Token::Structure' );
+
+				if ( $token eq '}' ) {
+					++$structure_depth ;
+					next;
+				}
+				elsif ( $token eq '{' ) {
+					--$structure_depth;
+					last if !$structure_depth;
+					next;
+				}
+			}
+			return 'Operator' if !$token; # no matching '{', probably an unbalanced '}'
+
+			# Scan past any whitespace
+			$token = undef;
+			while ( $cursor >= 0 ) {
+				$token = $tokens->[$cursor--];
+				last if $token->significant;
+			}
+			return 'Operator' if !$token; # Document began with what must be a hash constructor.
+			return 'Operator' if $token->isa( 'PPI::Token::Symbol' ); # subscript
+			return 'Operator' if $token->content eq '->' || $token->content eq '}' || $token->content eq ']'; # subscript
+
+			my $content = $token->content;
+			my $produces_or_wants_value = $token->isa('PPI::Token::Word') && ( $content eq 'do' or $content eq 'eval' );
+			return $produces_or_wants_value ? 'Operator' : 'Cast';
+		}
+		elsif ( $token->content eq ';' || $token->content eq '(' || $token->content eq '{' || $token->content eq '[' ) {
+			return 'Cast';
+		}
+	}
+	elsif ( $token->isa('PPI::Token::Cast') ) {
+		return 'Cast';
+	}
+	elsif ( $token->isa('PPI::Token::Operator') ) {
+		return 'Cast';
+	}
+	elsif ( $token->isa('PPI::Token::Label') ) {
+		return 'Cast';
+	}
+	elsif ( $token->isa('PPI::Token::Word') ) {
+		$token = undef;
+		while ( $cursor >= 0 ) {
+			$token = $tokens->[$cursor--];
+			last if $token->significant;
+		}
+		return 'Cast'
+                        if !$token || $token->content ne '->';
+	}
+
+	return 'Operator';
 }
 
 # Are we at a location where a ':' would indicate a subroutine attribute

--- a/t/ppi_token_unknown.t
+++ b/t/ppi_token_unknown.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Unknown
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 73;
+use Test::More tests => 70;
 
 use PPI;
 
@@ -11,17 +11,12 @@ sub o { test_cast_or_op( @_ ) }
 sub c { test_cast_or_op( @_, 1 ) }
 
 OPERATOR_CAST: {
-	o '$c{d}*$e;';
-	o '$c{d} *$e';
-	o '1%$a';
-	
-#	# * % &
-#	# $ @ % * {
 	o '1*$a';
 	o '1*@a';
 	o '1*%a';
 	o '1**a';
 	o '1**{$a}';
+	o '1*={$a}';  # doesn't compile, but make sure *= is operator
 	o '1*{2}';
 	o '1*{2=>2}';  # same as '1*{2}'
 

--- a/t/ppi_token_unknown.t
+++ b/t/ppi_token_unknown.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Unknown
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 3;
+use Test::More tests => 73;
 
 use PPI;
 
@@ -11,31 +11,276 @@ sub o { test_cast_or_op( @_ ) }
 sub c { test_cast_or_op( @_, 1 ) }
 
 OPERATOR_CAST: {
-	o '$c{d}*$e';
+	o '$c{d}*$e;';
+	o '$c{d} *$e';
 	o '1%$a';
 	
-	# * % &
-	# $ @ % * {
+#	# * % &
+#	# $ @ % * {
 	o '1*$a';
 	o '1*@a';
 	o '1*%a';
 	o '1**a';
 	o '1**{$a}';
 	o '1*{2}';
+	o '1*{2=>2}';  # same as '1*{2}'
 
 	o '1%$a';
 	o '1%@a';
 	o '1%%a';
 	o '1%*a';
 	o '1%{2}';
+	o '1%{2=>2}';  # same as '1%{2}'
 
 	o '1&$a';
 	o '1&@a';
 	o '1&%a';
 	o '1&*a';
 	o '1&{2}';
+	o '1&{2=>2}';  # same as '1&{2}'
+        o '$obj&$obj';
 	
+	c '*$a';
+	c 'package foo {} *$a';
+	c 'keys %$a';
+	c 'keys %{$a}';
+	c 'values %$a';
+	c 'values %{$a}';
+
+        test_complex(
+                'map {1} %{$args}',
+		[
+			'PPI::Token::Word' => 'map',
+			'PPI::Structure::Block' => '{1}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '1',
+			'PPI::Token::Number' => '1',
+			'PPI::Token::Structure' => '}',
+			'PPI::Token::Cast' => '%',
+                        'PPI::Structure::Block' => '{$args}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '$args',
+			'PPI::Token::Symbol' => '$args',
+			'PPI::Token::Structure' => '}',
+		]
+        );
+        test_complex(
+                'map {1} @{$args}',
+		[
+			'PPI::Token::Word' => 'map',
+			'PPI::Structure::Block' => '{1}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '1',
+			'PPI::Token::Number' => '1',
+			'PPI::Token::Structure' => '}',
+			'PPI::Token::Cast' => '@',
+                        'PPI::Structure::Block' => '{$args}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '$args',
+			'PPI::Token::Symbol' => '$args',
+			'PPI::Token::Structure' => '}',
+		]
+        );
+        test_complex(
+                'map {1} *{$args}',
+		[
+			'PPI::Token::Word' => 'map',
+			'PPI::Structure::Block' => '{1}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '1',
+			'PPI::Token::Number' => '1',
+			'PPI::Token::Structure' => '}',
+			'PPI::Token::Cast' => '*',
+                        'PPI::Structure::Block' => '{$args}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '$args',
+			'PPI::Token::Symbol' => '$args',
+			'PPI::Token::Structure' => '}',
+		]
+        );
+
+	test_complex(
+		'} *$a', # unbalanced '}' before '*', arbitrary decision
+		[
+			'PPI::Statement::UnmatchedBrace' => '}',
+			'PPI::Token::Structure' => '}',
+			'PPI::Statement' => '*$a',
+			'PPI::Token::Operator' => '*',
+			'PPI::Token::Symbol' => '$a',
+		]
+	);
+
+	test_complex(
+		'eval {2}*$a',
+		[
+			'PPI::Token::Word' => 'eval',
+			'PPI::Structure::Block' => '{2}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '2',
+			'PPI::Token::Number' => '2',
+			'PPI::Token::Structure' => '}',
+			'PPI::Token::Operator' => '*',
+			'PPI::Token::Symbol' => '$a',
+		]
+	);
+
+	test_complex(
+		'sub foo {} *$a=$b;',
+		[
+			'PPI::Statement::Sub' => 'sub foo {}',
+			'PPI::Token::Word' => 'sub',
+			'PPI::Token::Word' => 'foo',
+			'PPI::Structure::Block' => '{}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Token::Structure' => '}',
+			'PPI::Statement' => '*$a=$b;',
+			'PPI::Token::Cast' => '*',
+			'PPI::Token::Symbol' => '$a',
+			'PPI::Token::Operator' => '=',
+			'PPI::Token::Symbol' => '$b',
+			'PPI::Token::Structure' => ';',
+		]
+	);
+
+	test_complex(
+		'$bar = \%*$foo', # multiple consecutive casts
+		[
+			'PPI::Token::Symbol' => '$bar',
+			'PPI::Token::Operator' => '=',
+			'PPI::Token::Cast' => '\\',
+			'PPI::Token::Cast' => '%',
+			'PPI::Token::Cast' => '*',
+			'PPI::Token::Symbol' => '$foo',
+		]
+	);
+
+	# See GitHub #60 for info on '$$$' not being parsed right
+	test_complex(
+                '$#tmp*$#tmp2',
+		[
+			'PPI::Token::ArrayIndex' => '$#tmp',
+			'PPI::Token::Operator' => '*',
+			'PPI::Token::ArrayIndex' => '$#tmp2',
+		]
+        );
+
+	test_complex(
+		'LABEL: *$a=$b',  # preceded by label
+		[
+			'PPI::Statement::Compound' => 'LABEL:',
+			'PPI::Token::Label' => 'LABEL:',
+			'PPI::Statement' => '*$a=$b',
+			'PPI::Token::Cast' => '*',
+			'PPI::Token::Symbol' => '$a',
+			'PPI::Token::Operator' => '=',
+			'PPI::Token::Symbol' => '$b',
+		]
+	);
+
+	test_complex(
+		'[ %{$req->parameters} ]',  # preceded by '['
+		[
+			'PPI::Structure::Constructor' => '[ %{$req->parameters} ]',
+			'PPI::Token::Structure' => '[',
+			'PPI::Statement' => '%{$req->parameters}',
+			'PPI::Token::Cast' => '%',
+			'PPI::Structure::Block' => '{$req->parameters}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '$req->parameters',
+			'PPI::Token::Symbol' => '$req',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Word' => 'parameters',
+			'PPI::Token::Structure' => '}',
+			'PPI::Token::Structure' => ']',
+		]
+	);
+	test_complex(
+		'( %{$req->parameters} )',  # preceded by '('
+		[
+			'PPI::Structure::List' => '( %{$req->parameters} )',
+			'PPI::Token::Structure' => '(',
+			'PPI::Statement::Expression' => '%{$req->parameters}',
+			'PPI::Token::Cast' => '%',
+			'PPI::Structure::Block' => '{$req->parameters}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '$req->parameters',
+			'PPI::Token::Symbol' => '$req',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Word' => 'parameters',
+			'PPI::Token::Structure' => '}',
+			'PPI::Token::Structure' => ')',
+		]
+	);
+
+	test_complex(
+		'++$i%$f',  # '%' wrongly a cast through 1.220.
+		[
+			'PPI::Statement' => '++$i%$f',
+			'PPI::Token::Operator' => '++',
+			'PPI::Token::Symbol' => '$i',
+			'PPI::Token::Operator' => '%',
+			'PPI::Token::Symbol' => '$f',
+		]
+	);
+
+        # subscripting prior to curlies
+	test_complex(
+		'$a->{a}*$x',
+		[
+			'PPI::Token::Symbol' => '$a',
+			'PPI::Token::Operator' => '->',
+			'PPI::Structure::Subscript' => '{a}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'a',
+			'PPI::Token::Word' => 'a',
+			'PPI::Token::Structure' => '}',
+			'PPI::Token::Operator' => '*',
+			'PPI::Token::Symbol' => '$x',
+		]
+	);
+	test_complex(
+		'$a->{a}{b}*$x',
+		[
+			'PPI::Token::Symbol' => '$a',
+			'PPI::Token::Operator' => '->',
+			'PPI::Structure::Subscript' => '{a}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'a',
+			'PPI::Token::Word' => 'a',
+			'PPI::Token::Structure' => '}',
+			'PPI::Structure::Subscript' => '{b}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'b',
+			'PPI::Token::Word' => 'b',
+			'PPI::Token::Structure' => '}',
+			'PPI::Token::Operator' => '*',
+			'PPI::Token::Symbol' => '$x',
+		]
+	);
+	test_complex(
+		'$a->[a]{b}*$x',
+		[
+			'PPI::Token::Symbol' => '$a',
+			'PPI::Token::Operator' => '->',
+			'PPI::Structure::Subscript' => '[a]',
+			'PPI::Token::Structure' => '[',
+			'PPI::Statement::Expression' => 'a',
+			'PPI::Token::Word' => 'a',
+			'PPI::Token::Structure' => ']',
+			'PPI::Structure::Subscript' => '{b}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'b',
+			'PPI::Token::Word' => 'b',
+			'PPI::Token::Structure' => '}',
+			'PPI::Token::Operator' => '*',
+			'PPI::Token::Symbol' => '$x',
+		]
+	);
 }
+
+
+exit 0;
+
 
 sub test_cast_or_op {
 	my ( $code, $want_cast ) = @_;
@@ -52,5 +297,27 @@ sub test_cast_or_op {
 
 	@tokens = map { ref $_, $_->content } @tokens;
 	diag explain \@tokens;
+	return;
+}
+
+
+sub test_complex {
+	my ( $code, $expected, $msg ) = @_;
+	$msg = $code if !defined $msg;
+
+	my $d = PPI::Document->new( \$code );
+	my $tokens = $d->find( sub { $_[1]->significant } );
+	$tokens = [ map { ref($_), $_->content() } @$tokens ];
+
+	if ( $expected->[0] !~ /^PPI::Statement/ ) {
+		unshift @$expected, 'PPI::Statement', $code;
+	}
+	my $ok = is_deeply( $tokens, $expected, $msg );
+	if ( !$ok ) {
+		diag ">>> $code -- $msg\n";
+		diag explain $tokens;
+		diag explain $expected;
+	}
+
 	return;
 }

--- a/t/ppi_token_unknown.t
+++ b/t/ppi_token_unknown.t
@@ -3,47 +3,217 @@
 # Unit testing for PPI::Token::Unknown
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 70;
+use Test::More tests => 133;
 
 use PPI;
 
-sub o { test_cast_or_op( @_ ) }
-sub c { test_cast_or_op( @_, 1 ) }
 
 OPERATOR_CAST: {
-	o '1*$a';
-	o '1*@a';
-	o '1*%a';
-	o '1**a';
-	o '1**{$a}';
-	o '1*={$a}';  # doesn't compile, but make sure *= is operator
-	o '1*{2}';
-	o '1*{2=>2}';  # same as '1*{2}'
+	my @nothing = ( '',  [] );
+	my @number =  ( '1', [ 'PPI::Token::Number' => '1' ] );
 
-	o '1%$a';
-	o '1%@a';
-	o '1%%a';
-	o '1%*a';
-	o '1%{2}';
-	o '1%{2=>2}';  # same as '1%{2}'
+	my @asterisk_op =    ( '*',  [ 'PPI::Token::Operator' => '*' ] );
+	my @asteriskeq_op =  ( '*=', [ 'PPI::Token::Operator' => '*=' ] );
+	my @percent_op =     ( '%',  [ 'PPI::Token::Operator' => '%' ] );
+	my @percenteq_op =   ( '%=', [ 'PPI::Token::Operator' => '%=' ] );
+	my @ampersand_op =   ( '&',  [ 'PPI::Token::Operator' => '&' ] );
+	my @ampersandeq_op = ( '&=', [ 'PPI::Token::Operator' => '&=' ] );
+	my @exp_op =         ( '**', [ 'PPI::Token::Operator' => '**' ] );
 
-	o '1&$a';
-	o '1&@a';
-	o '1&%a';
-	o '1&*a';
-	o '1&{2}';
-	o '1&{2=>2}';  # same as '1&{2}'
-        o '$obj&$obj';
-	
-	c '*$a';
-	c 'package foo {} *$a';
-	c 'keys %$a';
-	c 'keys %{$a}';
-	c 'values %$a';
-	c 'values %{$a}';
+	my @asterisk_cast =  ( '*', [ 'PPI::Token::Cast' => '*' ] );
+	my @percent_cast =   ( '%', [ 'PPI::Token::Cast' => '%' ] );
+	my @ampersand_cast = ( '&', [ 'PPI::Token::Cast' => '&' ] );
+	my @at_cast =        ( '@',  [ 'PPI::Token::Cast' => '@' ] );
 
-        test_complex(
-                'map {1} %{$args}',
+	my @scalar = ( '$a', [ 'PPI::Token::Symbol' => '$a' ] );
+	my @list = ( '@a', [ 'PPI::Token::Symbol' => '@a' ] );
+	my @hash = ( '%a', [ 'PPI::Token::Symbol' => '%a' ] );
+	my @glob = ( '*a', [ 'PPI::Token::Symbol' => '*a' ] );
+	my @bareword = ( 'word', [ 'PPI::Token::Word' => 'word' ] );
+	my @hashctor1 = (
+		'{2}',
+		[
+#			'PPI::Structure::Constructor' => '{2}',
+			'PPI::Structure::Block' => '{2}',  # should be constructor
+			'PPI::Token::Structure' => '{',
+#			'PPI::Statement::Expression' => '2',
+			'PPI::Statement' => '2',  # should be expression
+			'PPI::Token::Number' => '2',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+	my @hashctor2 = (
+		'{x=>2}',
+		[
+#			'PPI::Structure::Constructor' => '{x=>2}',
+			'PPI::Structure::Block' => '{x=>2}',  # should be constructor
+			'PPI::Token::Structure' => '{',
+#			'PPI::Statement::Expression' => 'x=>2',
+			'PPI::Statement' => 'x=>2',  # should be expression
+			'PPI::Token::Word' => 'x',
+			'PPI::Token::Operator' => '=>',
+			'PPI::Token::Number' => '2',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+	my @hashctor3 = (
+		'{$args}',
+		[
+#			'PPI::Structure::Constructor' => '{$args}',
+			'PPI::Structure::Block' => '{$args}',  # should be constructor
+			'PPI::Token::Structure' => '{',
+#			'PPI::Statement::Expression' => '$args',
+			'PPI::Statement' => '$args',  # should be expression
+			'PPI::Token::Symbol' => '$args',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+	my @listctor = @hashctor3;
+
+	test_varying_whitespace( @number, @asterisk_op, @scalar );
+	test_varying_whitespace( @number, @asterisk_op, @list );
+	test_varying_whitespace( @number, @asterisk_op, @hash );
+	test_varying_whitespace( @number, @asterisk_op, @hashctor1 );
+	test_varying_whitespace( @number, @asterisk_op, @hashctor2 );
+	test_varying_whitespace( @number, @asterisk_op, @hashctor3 );
+	test_varying_whitespace( @number, @exp_op, @bareword );
+	test_varying_whitespace( @number, @exp_op, @hashctor3 );  # doesn't compile, but make sure ** is operator
+	test_varying_whitespace( @number, @asteriskeq_op, @bareword );
+	test_varying_whitespace( @number, @asteriskeq_op, @hashctor3 );  # doesn't compile, but make sure it's an operator
+	test_varying_whitespace( @nothing, @asterisk_cast, @scalar );
+
+	test_varying_whitespace( @number, @percent_op, @scalar );
+	test_varying_whitespace( @number, @percent_op, @list );
+	test_varying_whitespace( @number, @percent_op, @hash );
+	test_varying_whitespace( @number, @percent_op, @glob );
+	test_varying_whitespace( @number, @percent_op, @hashctor1 );
+	test_varying_whitespace( @number, @percent_op, @hashctor2 );
+	test_varying_whitespace( @number, @percent_op, @hashctor3 );
+	test_varying_whitespace( @number, @percenteq_op, @bareword );
+	test_varying_whitespace( @number, @percenteq_op, @hashctor3 );  # doesn't compile, but make sure it's an operator
+	test_varying_whitespace( @nothing, @percent_cast, @scalar );
+
+	test_varying_whitespace( @number, @ampersand_op, @scalar );
+	test_varying_whitespace( @number, @ampersand_op, @list );
+	test_varying_whitespace( @number, @ampersand_op, @hash );
+	test_varying_whitespace( @number, @ampersand_op, @glob );
+	test_varying_whitespace( @number, @ampersand_op, @hashctor1 );
+	test_varying_whitespace( @number, @ampersand_op, @hashctor2 );
+	test_varying_whitespace( @number, @ampersand_op, @hashctor3 );
+	test_varying_whitespace( @number, @ampersandeq_op, @bareword );
+	test_varying_whitespace( @number, @ampersandeq_op, @hashctor3 );  # doesn't compile, but make sure it's an operator
+	test_varying_whitespace( @nothing, @ampersand_cast, @scalar );
+
+	my @plus = ( '+', [ 'PPI::Token::Operator' => '+', ] );
+	my @ex = ( 'x', [ 'PPI::Token::Operator' => 'x', ] );
+	test_varying_whitespace( @plus, @asterisk_cast, @scalar );
+	test_varying_whitespace( @plus, @asterisk_cast, @hashctor3 );
+	test_varying_whitespace( @plus, @percent_cast, @scalar );
+	test_varying_whitespace( @plus, @percent_cast, @hashctor3 );
+	test_varying_whitespace( @plus, @ampersand_cast, @scalar );
+	test_varying_whitespace( @plus, @ampersand_cast, @hashctor3 );
+	test_varying_whitespace( @ex, @asterisk_cast, @scalar );
+	test_varying_whitespace( @ex, @asterisk_cast, @hashctor3 );
+	test_varying_whitespace( @ex, @percent_cast, @scalar );
+	test_varying_whitespace( @ex, @percent_cast, @hashctor3 );
+	test_varying_whitespace( @ex, @ampersand_cast, @scalar );
+	test_varying_whitespace( @ex, @ampersand_cast, @hashctor3 );
+
+	my @single = ( "'3'", [ 'PPI::Token::Quote::Single' => "'3'", ] );
+	test_varying_whitespace( @single, @asterisk_op, @scalar );
+	test_varying_whitespace( @single, @asterisk_op, @hashctor3 );
+	test_varying_whitespace( @single, @percent_op, @scalar );
+	test_varying_whitespace( @single, @percent_op, @hashctor3 );
+	test_varying_whitespace( @single, @ampersand_op, @scalar );
+	test_varying_whitespace( @single, @ampersand_op, @hashctor3 );
+
+	my @double = ( '"3"', [ 'PPI::Token::Quote::Double' => '"3"', ] );
+	test_varying_whitespace( @double, @asterisk_op, @scalar );
+	test_varying_whitespace( @double, @asterisk_op, @hashctor3 );
+	test_varying_whitespace( @double, @percent_op, @scalar );
+	test_varying_whitespace( @double, @percent_op, @hashctor3 );
+	test_varying_whitespace( @double, @ampersand_op, @scalar );
+	test_varying_whitespace( @double, @ampersand_op, @hashctor3 );
+
+	test_varying_whitespace( @scalar, @asterisk_op, @scalar );
+	test_varying_whitespace( @scalar, @percent_op, @scalar );
+	test_varying_whitespace( @scalar, @ampersand_op, @scalar );
+
+	my @package = (
+		'package foo {}',
+		[
+			'PPI::Statement::Package' => 'package foo {}',
+			'PPI::Token::Word' => 'package',
+			'PPI::Token::Word' => 'foo',
+			'PPI::Structure::Block' => '{}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+	test_varying_whitespace( @package, @asterisk_cast, @scalar, 1 );
+	test_varying_whitespace( @package, @asterisk_cast, @hashctor3, 1 );
+	test_varying_whitespace( @package, @percent_cast, @scalar, 1 );
+	test_varying_whitespace( @package, @percent_cast, @hashctor3, 1 );
+	test_varying_whitespace( @package, @ampersand_cast, @scalar, 1 );
+	test_varying_whitespace( @package, @ampersand_cast, @hashctor3, 1 );
+	test_varying_whitespace( @package, @at_cast, @scalar, 1 );
+	test_varying_whitespace( @package, @at_cast, @listctor, 1 );
+
+	my @sub = (
+		'sub foo {}',
+		[
+			'PPI::Statement::Sub' => 'sub foo {}',
+			'PPI::Token::Word' => 'sub',
+			'PPI::Token::Word' => 'foo',
+			'PPI::Structure::Block' => '{}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+	test_varying_whitespace( @sub, @asterisk_cast, @scalar, 1 );
+	test_varying_whitespace( @sub, @asterisk_cast, @hashctor3, 1 );
+	test_varying_whitespace( @sub, @percent_cast, @scalar, 1 );
+	test_varying_whitespace( @sub, @percent_cast, @hashctor3, 1 );
+	test_varying_whitespace( @sub, @ampersand_cast, @scalar, 1 );
+	test_varying_whitespace( @sub, @ampersand_cast, @hashctor3, 1 );
+	test_varying_whitespace( @sub, @at_cast, @scalar, 1 );
+	test_varying_whitespace( @sub, @at_cast, @listctor, 1 );
+
+	my @statement = (
+		'1;',
+		[
+			'PPI::Statement' => '1;',
+			'PPI::Token::Number' => '1',
+			'PPI::Token::Structure' => ';',
+		]
+	);
+	test_varying_whitespace( @statement, @asterisk_cast, @scalar, 1 );
+	test_varying_whitespace( @statement, @asterisk_cast, @hashctor3, 1 );
+	test_varying_whitespace( @statement, @percent_cast, @scalar, 1 );
+	test_varying_whitespace( @statement, @percent_cast, @hashctor3, 1 );
+	test_varying_whitespace( @statement, @ampersand_cast, @scalar, 1 );
+	test_varying_whitespace( @statement, @ampersand_cast, @hashctor3, 1 );
+	test_varying_whitespace( @statement, @at_cast, @scalar, 1 );
+	test_varying_whitespace( @statement, @at_cast, @listctor, 1 );
+
+	my @label = (
+		'LABEL:',
+		[
+			'PPI::Statement::Compound' => 'LABEL:',
+			'PPI::Token::Label' => 'LABEL:',
+		]
+	);
+	test_varying_whitespace( @label, @asterisk_cast, @scalar, 1 );
+	test_varying_whitespace( @label, @asterisk_cast, @hashctor3, 1 );
+	test_varying_whitespace( @label, @percent_cast, @scalar, 1 );
+	test_varying_whitespace( @label, @percent_cast, @hashctor3, 1 );
+	test_varying_whitespace( @label, @ampersand_cast, @scalar, 1 );
+	test_varying_whitespace( @label, @ampersand_cast, @hashctor3, 1 );
+	test_varying_whitespace( @label, @at_cast, @scalar, 1 );
+	test_varying_whitespace( @label, @at_cast, @listctor, 1 );
+
+	my @map = (
+		'map {1}',
 		[
 			'PPI::Token::Word' => 'map',
 			'PPI::Structure::Block' => '{1}',
@@ -51,50 +221,127 @@ OPERATOR_CAST: {
 			'PPI::Statement' => '1',
 			'PPI::Token::Number' => '1',
 			'PPI::Token::Structure' => '}',
-			'PPI::Token::Cast' => '%',
-                        'PPI::Structure::Block' => '{$args}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement' => '$args',
-			'PPI::Token::Symbol' => '$args',
-			'PPI::Token::Structure' => '}',
 		]
-        );
-        test_complex(
-                'map {1} @{$args}',
-		[
-			'PPI::Token::Word' => 'map',
-			'PPI::Structure::Block' => '{1}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement' => '1',
-			'PPI::Token::Number' => '1',
-			'PPI::Token::Structure' => '}',
-			'PPI::Token::Cast' => '@',
-                        'PPI::Structure::Block' => '{$args}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement' => '$args',
-			'PPI::Token::Symbol' => '$args',
-			'PPI::Token::Structure' => '}',
-		]
-        );
-        test_complex(
-                'map {1} *{$args}',
-		[
-			'PPI::Token::Word' => 'map',
-			'PPI::Structure::Block' => '{1}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement' => '1',
-			'PPI::Token::Number' => '1',
-			'PPI::Token::Structure' => '}',
-			'PPI::Token::Cast' => '*',
-                        'PPI::Structure::Block' => '{$args}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement' => '$args',
-			'PPI::Token::Symbol' => '$args',
-			'PPI::Token::Structure' => '}',
-		]
-        );
+	);
+	test_varying_whitespace( @map, @asterisk_cast, @scalar );
+	test_varying_whitespace( @map, @asterisk_cast, @hashctor3 );
+	test_varying_whitespace( @map, @percent_cast, @scalar );
+	test_varying_whitespace( @map, @percent_cast, @hashctor3 );
+	test_varying_whitespace( @map, @ampersand_cast, @scalar );
+	test_varying_whitespace( @map, @ampersand_cast, @hashctor3 );
+	test_varying_whitespace( @map, @at_cast, @scalar );
+	test_varying_whitespace( @map, @at_cast, @listctor );
 
-	test_complex(
+	my @evalblock = (
+		'eval {2}',
+		[
+			'PPI::Token::Word' => 'eval',
+			'PPI::Structure::Block' => '{2}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement' => '2',
+			'PPI::Token::Number' => '2',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+	test_varying_whitespace( @evalblock, @asterisk_op, @scalar );
+	test_varying_whitespace( @evalblock, @asterisk_op, @hashctor3 );
+	test_varying_whitespace( @evalblock, @percent_op, @scalar );
+	test_varying_whitespace( @evalblock, @percent_op, @hashctor3 );
+	test_varying_whitespace( @evalblock, @ampersand_op, @scalar );
+	test_varying_whitespace( @evalblock, @ampersand_op, @hashctor3 );
+
+	my @evalstring = (
+		'eval "2"',
+		[
+			'PPI::Token::Word' => 'eval',
+			'PPI::Token::Quote::Double' => '"2"',
+		]
+	);
+	test_varying_whitespace( @evalstring, @asterisk_op, @scalar );
+	test_varying_whitespace( @evalstring, @asterisk_op, @hashctor3 );
+	test_varying_whitespace( @evalstring, @percent_op, @scalar );
+	test_varying_whitespace( @evalstring, @percent_op, @hashctor3 );
+	test_varying_whitespace( @evalstring, @ampersand_op, @scalar );
+	test_varying_whitespace( @evalstring, @ampersand_op, @hashctor3 );
+
+	my @curly_subscript1 = (
+		'$y->{x}',
+		[
+			'PPI::Token::Symbol' => '$y',
+			'PPI::Token::Operator' => '->',
+			'PPI::Structure::Subscript' => '{x}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'x',
+			'PPI::Token::Word' => 'x',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+	my @curly_subscript2 = (
+		'$y->{z}{x}',
+		[
+			'PPI::Token::Symbol' => '$y',
+			'PPI::Token::Operator' => '->',
+			'PPI::Structure::Subscript' => '{z}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'z',
+			'PPI::Token::Word' => 'z',
+			'PPI::Token::Structure' => '}',
+			'PPI::Structure::Subscript' => '{x}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'x',
+			'PPI::Token::Word' => 'x',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+	my @curly_subscript3 = (
+		'$y->[z]{x}',
+		[
+			'PPI::Token::Symbol' => '$y',
+			'PPI::Token::Operator' => '->',
+			'PPI::Structure::Subscript' => '[z]',
+			'PPI::Token::Structure' => '[',
+			'PPI::Statement::Expression' => 'z',
+			'PPI::Token::Word' => 'z',
+			'PPI::Token::Structure' => ']',
+			'PPI::Structure::Subscript' => '{x}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'x',
+			'PPI::Token::Word' => 'x',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+	my @square_subscript1 = (
+		'$y->[x]',
+		[
+			'PPI::Token::Symbol' => '$y',
+			'PPI::Token::Operator' => '->',
+			'PPI::Structure::Subscript' => '[x]',
+			'PPI::Token::Structure' => '[',
+			'PPI::Statement::Expression' => 'x',
+			'PPI::Token::Word' => 'x',
+			'PPI::Token::Structure' => ']',
+		]
+	);
+	test_varying_whitespace( @curly_subscript1, @asterisk_op, @scalar );
+	test_varying_whitespace( @curly_subscript1, @percent_op, @scalar );
+	test_varying_whitespace( @curly_subscript1, @ampersand_op, @scalar );
+	test_varying_whitespace( @curly_subscript2, @asterisk_op, @scalar );
+	test_varying_whitespace( @curly_subscript2, @percent_op, @scalar );
+	test_varying_whitespace( @curly_subscript2, @ampersand_op, @scalar );
+	test_varying_whitespace( @curly_subscript3, @asterisk_op, @scalar );
+	test_varying_whitespace( @curly_subscript3, @percent_op, @scalar );
+	test_varying_whitespace( @curly_subscript3, @ampersand_op, @scalar );
+	test_varying_whitespace( @square_subscript1, @asterisk_op, @scalar );
+	test_varying_whitespace( @square_subscript1, @percent_op, @scalar );
+	test_varying_whitespace( @square_subscript1, @ampersand_op, @scalar );
+
+	test_varying_whitespace( 'keys', [ 'PPI::Token::Word' => 'keys' ],     @percent_cast, @scalar );
+	test_varying_whitespace( 'values', [ 'PPI::Token::Word' => 'values' ], @percent_cast, @scalar );
+
+	test_varying_whitespace( 'keys', [ 'PPI::Token::Word' => 'keys' ],     @percent_cast, @hashctor3 );
+	test_varying_whitespace( 'values', [ 'PPI::Token::Word' => 'values' ], @percent_cast, @hashctor3 );
+
+	test_statement(
 		'} *$a', # unbalanced '}' before '*', arbitrary decision
 		[
 			'PPI::Statement::UnmatchedBrace' => '}',
@@ -105,39 +352,7 @@ OPERATOR_CAST: {
 		]
 	);
 
-	test_complex(
-		'eval {2}*$a',
-		[
-			'PPI::Token::Word' => 'eval',
-			'PPI::Structure::Block' => '{2}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement' => '2',
-			'PPI::Token::Number' => '2',
-			'PPI::Token::Structure' => '}',
-			'PPI::Token::Operator' => '*',
-			'PPI::Token::Symbol' => '$a',
-		]
-	);
-
-	test_complex(
-		'sub foo {} *$a=$b;',
-		[
-			'PPI::Statement::Sub' => 'sub foo {}',
-			'PPI::Token::Word' => 'sub',
-			'PPI::Token::Word' => 'foo',
-			'PPI::Structure::Block' => '{}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Token::Structure' => '}',
-			'PPI::Statement' => '*$a=$b;',
-			'PPI::Token::Cast' => '*',
-			'PPI::Token::Symbol' => '$a',
-			'PPI::Token::Operator' => '=',
-			'PPI::Token::Symbol' => '$b',
-			'PPI::Token::Structure' => ';',
-		]
-	);
-
-	test_complex(
+	test_statement(
 		'$bar = \%*$foo', # multiple consecutive casts
 		[
 			'PPI::Token::Symbol' => '$bar',
@@ -149,30 +364,16 @@ OPERATOR_CAST: {
 		]
 	);
 
-	# See GitHub #60 for info on '$$$' not being parsed right
-	test_complex(
-                '$#tmp*$#tmp2',
+	test_statement(
+		'$#tmp*$#tmp2',
 		[
 			'PPI::Token::ArrayIndex' => '$#tmp',
 			'PPI::Token::Operator' => '*',
 			'PPI::Token::ArrayIndex' => '$#tmp2',
 		]
-        );
-
-	test_complex(
-		'LABEL: *$a=$b',  # preceded by label
-		[
-			'PPI::Statement::Compound' => 'LABEL:',
-			'PPI::Token::Label' => 'LABEL:',
-			'PPI::Statement' => '*$a=$b',
-			'PPI::Token::Cast' => '*',
-			'PPI::Token::Symbol' => '$a',
-			'PPI::Token::Operator' => '=',
-			'PPI::Token::Symbol' => '$b',
-		]
 	);
 
-	test_complex(
+	test_statement(
 		'[ %{$req->parameters} ]',  # preceded by '['
 		[
 			'PPI::Structure::Constructor' => '[ %{$req->parameters} ]',
@@ -189,7 +390,7 @@ OPERATOR_CAST: {
 			'PPI::Token::Structure' => ']',
 		]
 	);
-	test_complex(
+	test_statement(
 		'( %{$req->parameters} )',  # preceded by '('
 		[
 			'PPI::Structure::List' => '( %{$req->parameters} )',
@@ -207,7 +408,7 @@ OPERATOR_CAST: {
 		]
 	);
 
-	test_complex(
+	test_statement(
 		'++$i%$f',  # '%' wrongly a cast through 1.220.
 		[
 			'PPI::Statement' => '++$i%$f',
@@ -217,86 +418,14 @@ OPERATOR_CAST: {
 			'PPI::Token::Symbol' => '$f',
 		]
 	);
-
-        # subscripting prior to curlies
-	test_complex(
-		'$a->{a}*$x',
-		[
-			'PPI::Token::Symbol' => '$a',
-			'PPI::Token::Operator' => '->',
-			'PPI::Structure::Subscript' => '{a}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement::Expression' => 'a',
-			'PPI::Token::Word' => 'a',
-			'PPI::Token::Structure' => '}',
-			'PPI::Token::Operator' => '*',
-			'PPI::Token::Symbol' => '$x',
-		]
-	);
-	test_complex(
-		'$a->{a}{b}*$x',
-		[
-			'PPI::Token::Symbol' => '$a',
-			'PPI::Token::Operator' => '->',
-			'PPI::Structure::Subscript' => '{a}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement::Expression' => 'a',
-			'PPI::Token::Word' => 'a',
-			'PPI::Token::Structure' => '}',
-			'PPI::Structure::Subscript' => '{b}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement::Expression' => 'b',
-			'PPI::Token::Word' => 'b',
-			'PPI::Token::Structure' => '}',
-			'PPI::Token::Operator' => '*',
-			'PPI::Token::Symbol' => '$x',
-		]
-	);
-	test_complex(
-		'$a->[a]{b}*$x',
-		[
-			'PPI::Token::Symbol' => '$a',
-			'PPI::Token::Operator' => '->',
-			'PPI::Structure::Subscript' => '[a]',
-			'PPI::Token::Structure' => '[',
-			'PPI::Statement::Expression' => 'a',
-			'PPI::Token::Word' => 'a',
-			'PPI::Token::Structure' => ']',
-			'PPI::Structure::Subscript' => '{b}',
-			'PPI::Token::Structure' => '{',
-			'PPI::Statement::Expression' => 'b',
-			'PPI::Token::Word' => 'b',
-			'PPI::Token::Structure' => '}',
-			'PPI::Token::Operator' => '*',
-			'PPI::Token::Symbol' => '$x',
-		]
-	);
 }
 
 
 exit 0;
 
 
-sub test_cast_or_op {
-	my ( $code, $want_cast ) = @_;
-
-	my $d        = PPI::Document->new( \$code );
-	my @tokens   = @{ $d->find( sub { 1 } ) };
-	my @types    = map { ref $_ } @tokens;
-	my $has_cast = grep { $_ eq 'PPI::Token::Cast' } @types;
-	my $has_op   = grep { $_ eq 'PPI::Token::Operator' } @types;
-	return
-	  if $want_cast
-	  ? ( ok( $has_cast, "$code: has cast" ) and ok( !$has_op, "$code: has no op" ) )
-	  : ( ok( $has_op, "$code: has op" ) and ok( !$has_cast, "$code: has no cast" ) );
-
-	@tokens = map { ref $_, $_->content } @tokens;
-	diag explain \@tokens;
-	return;
-}
-
-
-sub test_complex {
+sub test_statement {
+	local $Test::Builder::Level = $Test::Builder::Level+1;
 	my ( $code, $expected, $msg ) = @_;
 	$msg = $code if !defined $msg;
 
@@ -305,7 +434,7 @@ sub test_complex {
 	$tokens = [ map { ref($_), $_->content() } @$tokens ];
 
 	if ( $expected->[0] !~ /^PPI::Statement/ ) {
-		unshift @$expected, 'PPI::Statement', $code;
+		$expected = [ 'PPI::Statement', $code, @$expected ];
 	}
 	my $ok = is_deeply( $tokens, $expected, $msg );
 	if ( !$ok ) {
@@ -313,6 +442,42 @@ sub test_complex {
 		diag explain $tokens;
 		diag explain $expected;
 	}
+
+	return;
+}
+
+
+sub test_varying_whitespace {
+	local $Test::Builder::Level = $Test::Builder::Level+1;
+	my( $left, $left_expected, $cast_or_op, $cast_or_op_expected, $right, $right_expected, $right_is_statement ) = @_;
+
+	assemble_and_test( "",  $left, $left_expected, $cast_or_op, $cast_or_op_expected, $right, $right_expected, $right_is_statement );
+#	assemble_and_test( " ", $left, $left_expected, $cast_or_op, $cast_or_op_expected, $right, $right_expected, $right_is_statement );
+#	assemble_and_test( "\t", $left, $left_expected, $cast_or_op, $cast_or_op_expected, $right, $right_expected, $right_is_statement );
+#	assemble_and_test( "\n", $left, $left_expected, $cast_or_op, $cast_or_op_expected, $right, $right_expected, $right_is_statement );
+#	assemble_and_test( "\f", $left, $left_expected, $cast_or_op, $cast_or_op_expected, $right, $right_expected, $right_is_statement );
+#	assemble_and_test( "\r", $left, $left_expected, $cast_or_op, $cast_or_op_expected, $right, $right_expected, $right_is_statement );  # fix this -- different breakage from \n, \t, etc.
+
+	return;
+}
+
+
+sub assemble_and_test {
+	local $Test::Builder::Level = $Test::Builder::Level+1;
+	my( $whitespace, $left, $left_expected, $cast_or_op, $cast_or_op_expected, $right, $right_expected, $right_is_statement ) = @_;
+
+	my $code = $left eq '' ? "$cast_or_op$whitespace$right" : "$left$whitespace$cast_or_op$whitespace$right";
+
+	if ( $right_is_statement ) {
+		$cast_or_op_expected = [ 'PPI::Statement' => "$cast_or_op$whitespace$right", @$cast_or_op_expected ];
+	}
+
+	my $expected = [
+		@$left_expected,
+		@$cast_or_op_expected,
+		@$right_expected,
+	];
+	test_statement( $code, $expected );
 
 	return;
 }


### PR DESCRIPTION
Have _cast_or_op rely on looking at prior tokens to determine whether *, %, or & is a cast or an operator.  Includes removing a bit of "Obvious GLOB cast" logic that was no longer needed.

Made the handling of *, %, and & more similar to each other, including removing a confusing regex in \* handling.

Lots more tests.
