### PR TITLE
Method op

### DIFF
--- a/lib/PPI/Token/Whitespace.pm
+++ b/lib/PPI/Token/Whitespace.pm
@@ -382,19 +382,30 @@ sub __TOKENIZER__on_char {
 		return 'Operator';
 
 	} elsif ( $char == 120 ) { # $char eq 'x'
-		# x followed immediately by a digit can be the x
-		# operator or a word.  Disambiguate by checking
-		# whether the previous token is an operator that cannot be
-		# followed by the x operator, e.g.: +.
-		#
-		# x followed immediately by '=' is the 'x=' operator, not
-		# 'x ='. An important exception is x followed immediately by
-		# '=>', which makes the x into a bareword.
-		pos $t->{line} = $t->{line_cursor} + 1;
-		return 'Operator'
-			if $t->_current_x_is_operator and $t->{line} =~ m/\G(?:\d|(?!(=>|[\w\s])))/gc;
+		# Could be a word, the x= operator, the x operator
+		# followed by whitespace, or the x operator without any
+		# space between itself and its operand, e.g.: '$a x3',
+		# which is the same as '$a x 3'.  _current_x_is_operator
+		# assumes we have a complete 'x' token, but we don't
+		# yet.  We may need to split this x character apart from
+		# what follows it.
+		if ( $t->_current_x_is_operator ) {
+			pos $t->{line} = $t->{line_cursor} + 1;
+			return 'Operator' if $t->{line} =~ m/\G(?:
+				\d  # x op with no whitespace e.g. 'x3'
+				|
+				(?!(  # negative lookahead
+					=>  # not on left of fat comma
+					|
+					\w  # not a word like "xyzzy"
+					|
+					\s  # not x op plus whitespace
+				))
+			)/gcx;
+		}
 
-		# Otherwise, commit like a normal bareword
+		# Otherwise, commit like a normal bareword, including x
+		# operator followed by whitespace.
 		return PPI::Token::Word->__TOKENIZER__commit($t);
 
 	} elsif ( $char == 45 ) { # $char eq '-'

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -798,14 +798,10 @@ sub _current_x_is_operator {
 	my ($prev, $prevprev) = @{ $self->_previous_significant_tokens(2) };
 	return if !$prev;
 
-	return 1 if $prevprev
-		and $prevprev->isa('PPI::Token::Operator')
-		and $prevprev->content eq "->"
-		and $prev->isa('PPI::Token::Word');
+	return !$self->__current_token_is_forced_word if $prev->isa('PPI::Token::Word');
 	
 	return (!$prev->isa('PPI::Token::Operator') || $X_CAN_FOLLOW_OPERATOR{$prev})
 		&& (!$prev->isa('PPI::Token::Structure') || $X_CAN_FOLLOW_STRUCTURE{$prev})
-		&& (!$prev->isa('PPI::Token::Word') || $X_CAN_FOLLOW_WORD{$prev})
 		&& !$prev->isa('PPI::Token::Label')
 	;
 }

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -842,7 +842,9 @@ sub __current_token_is_forced_word {
 		# version string.  However, we don't want to be fooled by 'package
 		# package v10' or 'use no v10'. We're a forced package unless we're
 		# preceded by 'package sub', in which case we're a version string.
-		return ( !$prevprev || !$USUALLY_FORCES{$prevprev->content} )
+		# We also have to make sure that the sub/package/etc doing the forcing
+		# is not a method call.
+		return ( !$prevprev || !($USUALLY_FORCES{$prevprev->content} || $prevprev->content eq '->') )
 			if $USUALLY_FORCES{$content};
 	}
 	# pos on $t->{line} is guaranteed to be set at this point.

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -792,12 +792,18 @@ sub _opcontext {
 # Assuming we are currently parsing the word 'x', return true
 # if previous tokens imply the x is an operator, false otherwise.
 sub _current_x_is_operator {
-	my $self = shift;
+	my ( $self ) = @_;
+	return if !@{$self->{tokens}};
 
-	my $prev = $self->_last_significant_token;
-	return 
-		$prev
-		&& (!$prev->isa('PPI::Token::Operator') || $X_CAN_FOLLOW_OPERATOR{$prev})
+	my ($prev, $prevprev) = @{ $self->_previous_significant_tokens(2) };
+	return if !$prev;
+
+	return 1 if $prevprev
+		and $prevprev->isa('PPI::Token::Operator')
+		and $prevprev->content eq "->"
+		and $prev->isa('PPI::Token::Word');
+	
+	return (!$prev->isa('PPI::Token::Operator') || $X_CAN_FOLLOW_OPERATOR{$prev})
 		&& (!$prev->isa('PPI::Token::Structure') || $X_CAN_FOLLOW_STRUCTURE{$prev})
 		&& (!$prev->isa('PPI::Token::Word') || $X_CAN_FOLLOW_WORD{$prev})
 		&& !$prev->isa('PPI::Token::Label')

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Operator
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 1144;
+use Test::More tests => 1147;
 
 use PPI;
 
@@ -38,6 +38,39 @@ PARSE_ALL_OPERATORS: {
 
 OPERATOR_X: {
 	my @tests = (
+		{
+			desc => 'generic bareword with integer',  # github #133
+			code => 'bareword x 3',
+			expected => [
+				'PPI::Token::Word' => 'bareword',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Operator' => 'x',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Number' => '3',
+			],
+		},
+		{
+			desc => 'generic bareword with integer run together',  # github #133
+			code => 'bareword x3',
+			expected => [
+				'PPI::Token::Word' => 'bareword',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Operator' => 'x',
+				'PPI::Token::Number' => '3',
+			],
+		},
+		{
+			desc => 'preceding word looks like a force but is not',  # github #133
+			code => '$a->package x3',
+			expected => [
+				'PPI::Token::Symbol' => '$a',
+				'PPI::Token::Operator' => '->',
+				'PPI::Token::Word' => 'package',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Operator' => 'x',
+				'PPI::Token::Number' => '3',
+			],
+		},
 		{
 			desc => 'method with integer',
 			code => 'sort { $a->package cmp $b->package } ();',

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Operator
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 1143;
+use Test::More tests => 1144;
 
 use PPI;
 
@@ -38,6 +38,34 @@ PARSE_ALL_OPERATORS: {
 
 OPERATOR_X: {
 	my @tests = (
+		{
+			desc => 'method with integer',
+			code => 'sort { $a->package cmp $b->package } ();',
+			expected => [
+				'PPI::Token::Word' => 'sort',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Structure::Block'=> '{ $a->package cmp $b->package }',
+				'PPI::Token::Structure'=> '{',
+				'PPI::Token::Whitespace'=> ' ',
+				'PPI::Statement'=> '$a->package cmp $b->package',
+				'PPI::Token::Symbol'=> '$a',
+				'PPI::Token::Operator'=> '->',
+				'PPI::Token::Word'=> 'package',
+				'PPI::Token::Whitespace'=> ' ',
+				'PPI::Token::Operator'=> 'cmp',
+				'PPI::Token::Whitespace'=> ' ',
+				'PPI::Token::Symbol'=> '$b',
+				'PPI::Token::Operator'=> '->',
+				'PPI::Token::Word'=> 'package',
+				'PPI::Token::Whitespace'=> ' ',
+				'PPI::Token::Structure'=> '}',
+				'PPI::Token::Whitespace'=> ' ',
+				'PPI::Structure::List'=> '()',
+				'PPI::Token::Structure'=> '(',
+				'PPI::Token::Structure'=> ')',
+				'PPI::Token::Structure'=> ';'
+			],
+		},
 		{
 			desc => 'method with integer',
 			code => 'c->d x 3',

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Operator
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 1142;
+use Test::More tests => 1143;
 
 use PPI;
 
@@ -38,6 +38,19 @@ PARSE_ALL_OPERATORS: {
 
 OPERATOR_X: {
 	my @tests = (
+		{
+			desc => 'method with integer',
+			code => 'c->d x 3',
+			expected => [
+				'PPI::Token::Word' => 'c',
+				'PPI::Token::Operator' => '->',
+				'PPI::Token::Word' => 'd',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Operator' => 'x',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Number' => '3',
+			],
+		},
 		{
 			desc => 'integer with integer',
 			code => '1 x 3',


### PR DESCRIPTION
Address post-1.220 regression whereby the operators that look like words, e.g. 'x', 'cmp', were being misidentified.
