### PR TITLE
remove use of Test::NoWarnings; only check for warnings in author mode.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,13 @@
 Revision history for Perl extension PPI
 
+1.221_01
+	Summary:
+	- support Perl 5.12 "package NAMESPACE VERSION BLOCK" syntax
+
+	Details:
+	- support Perl 5.12 "package NAMESPACE VERSION BLOCK" syntax
+	  (RT #67831, GitHub #70) (BDFOY, MOREGAN)
+
 1.220 Tue 11 Nov 2014
 	Summary:
 	- incompatible behavior fixes on PPI::Statement::Sub->prototype

--- a/Changes
+++ b/Changes
@@ -15,6 +15,8 @@ Revision history for Perl extension PPI
 	  strings (RT #74527, GitHub #65) (JAE, MOREGAN)
 	- Prevent 'use' and 'no' package names from being parsed as
 	  operators (MOREGAN)
+	- Prevent left side of fat comma from parsing as operator
+	  operators (MOREGAN)
 
 1.220 Tue 11 Nov 2014
 	Summary:

--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 Revision history for Perl extension PPI
+	- Fix 1.218 regression where packages, subs, and words after
+	  labels like /^x\d+/ would parse as x operator (GitHub #122)
+	  (MOREGAN)
 
 1.221_01
 	Summary:

--- a/Changes
+++ b/Changes
@@ -13,6 +13,8 @@ Revision history for Perl extension PPI
 	  strings (GitHub #76) (MOREGAN)
 	- Prevent sub names like 'v10' from being parsed as version
 	  strings (RT #74527, GitHub #65) (JAE, MOREGAN)
+	- Prevent 'use' and 'no' package names from being parsed as
+	  operators (MOREGAN)
 
 1.220 Tue 11 Nov 2014
 	Summary:

--- a/Changes
+++ b/Changes
@@ -9,6 +9,8 @@ Revision history for Perl extension PPI
 	  (RT #67831, GitHub #70) (BDFOY, MOREGAN)
 	- Prevent package names like 'x' from being parsed as operators
 	  (GitHub #75) (MOREGAN)
+	- Prevent package names like 'v10' from being parsed as version
+	  strings (GitHub #76) (MOREGAN)
 
 1.220 Tue 11 Nov 2014
 	Summary:

--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@ Revision history for Perl extension PPI
 	Details:
 	- support Perl 5.12 "package NAMESPACE VERSION BLOCK" syntax
 	  (RT #67831, GitHub #70) (BDFOY, MOREGAN)
+	- Prevent package names like 'x' from being parsed as operators
+	  (GitHub #75) (MOREGAN)
 
 1.220 Tue 11 Nov 2014
 	Summary:

--- a/Changes
+++ b/Changes
@@ -11,6 +11,8 @@ Revision history for Perl extension PPI
 	  (GitHub #75) (MOREGAN)
 	- Prevent package names like 'v10' from being parsed as version
 	  strings (GitHub #76) (MOREGAN)
+	- Prevent sub names like 'v10' from being parsed as version
+	  strings (RT #74527, GitHub #65) (JAE, MOREGAN)
 
 1.220 Tue 11 Nov 2014
 	Summary:

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,6 +40,7 @@ test_requires 'Test::More'       => '0.86';
 test_requires 'Test::NoWarnings' => '0.084';
 test_requires 'Test::Object'     => '0.07';
 test_requires 'Test::SubCalls'   => '1.07';
+test_requires 'Test::Deep';
 
 # Force the existence of the weaken function
 # (which some distributions annoyingly don't have)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,7 +37,6 @@ requires 'Storable'    => '2.17';
 test_requires 'Class::Inspector' => '1.22';
 test_requires 'File::Remove'     => '1.42';
 test_requires 'Test::More'       => '0.86';
-test_requires 'Test::NoWarnings' => '0.084';
 test_requires 'Test::Object'     => '0.07';
 test_requires 'Test::SubCalls'   => '1.07';
 test_requires 'Test::Deep';

--- a/lib/PPI/Cache.pm
+++ b/lib/PPI/Cache.pm
@@ -268,7 +268,7 @@ sub _md5hex {
 	my $it     = _SCALAR($_[0])
 		? PPI::Util::md5hex(${$_[0]})
 		: $_[0];
-	return (defined $it and ! ref $it and $it =~ /^[a-f0-9]{32}\z/si)
+	return (defined $it and ! ref $it and $it =~ /^[[:xdigit:]]{32}\z/s)
 		? lc $it
 		: undef;
 }

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -1119,6 +1119,12 @@ sub _curly {
 					and return 'PPI::Structure::Subscript';
 			}
 		}
+
+		# Are we the second or third argument of package?
+		# E.g.: 'package Foo {}' or 'package Foo v1.2.3 {}'
+		return 'PPI::Structure::Block'
+			if $Parent->isa('PPI::Statement::Package');
+
 		if ( $CURLY_CLASSES{$content} ) {
 			# Known type
 			return $CURLY_CLASSES{$content};

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -1120,6 +1120,10 @@ sub _curly {
 			}
 		}
 
+		# Are we the last argument of sub?
+		# E.g.: 'sub foo {}', 'sub foo ($) {}'
+		return 'PPI::Structure::Block' if $Parent->isa('PPI::Statement::Sub');
+
 		# Are we the second or third argument of package?
 		# E.g.: 'package Foo {}' or 'package Foo v1.2.3 {}'
 		return 'PPI::Structure::Block'

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -696,22 +696,23 @@ sub _continues {
 		return '';
 	}
 
-	# Alrighty then, there are only five implied end statement types,
-	# ::Scheduled blocks, ::Sub declarations, ::Compound, ::Given, and ::When
-	# statements.
-	unless ( ref($Statement) =~ /\b(?:Scheduled|Sub|Compound|Given|When)$/ ) {
-		return 1;
-	}
+	# Alrighty then, there are six implied-end statement types:
+	# ::Scheduled blocks, ::Sub declarations, ::Compound, ::Given, ::When,
+	# and ::Package statements.
+	return 1
+		if ref $Statement !~ /\b(?:Scheduled|Sub|Compound|Given|When|Package)$/;
 
-	# Of these five, ::Scheduled, ::Sub, ::Given, and ::When follow the same
-	# simple rule and can be handled first.
+	# Of these six, ::Scheduled, ::Sub, ::Given, and ::When follow the same
+	# simple rule and can be handled first.  The block form of ::Package
+	# follows the rule, too.  (The non-block form of ::Package
+	# requires a statement terminator, and thus doesn't need to have
+	# an implied end detected.)
 	my @part      = $Statement->schildren;
 	my $LastChild = $part[-1];
-	unless ( $Statement->isa('PPI::Statement::Compound') ) {
-		# If the last significant element of the statement is a block,
-		# then a scheduled statement is done, no questions asked.
-		return ! $LastChild->isa('PPI::Structure::Block');
-	}
+	# If the last significant element of the statement is a block,
+	# then an implied-end statement is done, no questions asked.
+	return !$LastChild->isa('PPI::Structure::Block')
+		if !$Statement->isa('PPI::Statement::Compound');
 
 	# Now we get to compound statements, which kind of suck (to lex).
 	# However, of them all, the 'if' type, which includes unless, are

--- a/lib/PPI/Statement/Package.pm
+++ b/lib/PPI/Statement/Package.pm
@@ -47,6 +47,9 @@ BEGIN {
 	@ISA     = 'PPI::Statement';
 }
 
+# Lexer clues
+sub __LEXER__normal() { '' }
+
 =pod
 
 =head2 namespace

--- a/lib/PPI/Statement/Sub.pm
+++ b/lib/PPI/Statement/Sub.pm
@@ -165,16 +165,16 @@ Returns true if it is a special reserved subroutine, or false if not.
 sub reserved {
 	my $self = shift;
 	my $name = $self->name or return '';
+	# perlsub is silent on whether reserveds can contain:
+	# - underscores;
+	# we allow them due to existing practice like CLONE_SKIP and __SUB__.
+	# - numbers; we allow them by PPI tradition.
 	$name eq uc $name;
 }
 
 1;
 
 =pod
-
-=head1 TO DO
-
-- Write unit tests for this package
 
 =head1 SUPPORT
 

--- a/lib/PPI/Token/Number/Hex.pm
+++ b/lib/PPI/Token/Number/Hex.pm
@@ -76,7 +76,7 @@ sub __TOKENIZER__on_char {
 	# Allow underscores straight through
 	return 1 if $char eq '_';
 
-	if ( $char =~ /[\da-f]/i ) {
+	if ( $char =~ /[[:xdigit:]]/ ) {
 		return 1;
 	}
 

--- a/lib/PPI/Token/Number/Version.pm
+++ b/lib/PPI/Token/Number/Version.pm
@@ -102,7 +102,11 @@ sub __TOKENIZER__on_char {
 sub __TOKENIZER__commit {
 	my $t = $_[1];
 
-	# Get the rest of the line
+	# Forced to be a word. Done.
+	return PPI::Token::Word->__TOKENIZER__commit($t)
+		if $t->__current_token_is_forced_word;
+
+	# Capture the rest of the token
 	pos $t->{line} = $t->{line_cursor};
 	if ( $t->{line} !~ m/\G(v\d+(?:\.\d+)*)/gc ) {
 		# This was not a v-string after all (it's a word)

--- a/lib/PPI/Token/QuoteLike/Words.pm
+++ b/lib/PPI/Token/QuoteLike/Words.pm
@@ -42,20 +42,27 @@ BEGIN {
 
 =head2 literal
 
-Returns the words contained.  Note that this method does not check the
+Returns the words contained as a list.  Note that this method does not check the
 context that the token is in; it always returns the list and not merely
 the last element if the token is in scalar context.
 
 =cut
 
 sub literal {
-	my $self    = shift;
-	my $section = $self->{sections}->[0];
-	return split ' ', substr(
-		$self->{content},
-		$section->{position},
-		$section->{size},
-	);
+	my ( $self ) = @_;
+
+	my $content = $self->_section_content(0);
+	return if !defined $content;
+
+	# Undo backslash escaping of '\', the left delimiter,
+	# and the right delimiter.  The right delimiter will
+	# only exist with paired delimiters: qw() qw[] qw<> qw{}.
+	my ( $left, $right ) = ( $self->_delimiters, '', '' );
+	$content =~ s/\\([\Q$left$right\\\E])/$1/g;
+
+	my @words = split ' ', $content;
+
+	return @words;
 }
 
 1;

--- a/lib/PPI/Token/Unknown.pm
+++ b/lib/PPI/Token/Unknown.pm
@@ -90,7 +90,7 @@ sub __TOKENIZER__on_char {
 				} elsif (
 					$p0->isa('PPI::Token::Structure')
 					and
-					$p0->content =~ /^(?:\)|\])$/
+					$p0->content =~ /^(?:\)|\]|\})$/
 				) {
 					$_class = 'Operator';
 				} else {

--- a/lib/PPI/Token/Whitespace.pm
+++ b/lib/PPI/Token/Whitespace.pm
@@ -203,7 +203,8 @@ sub __TOKENIZER__on_line_start {
 
 sub __TOKENIZER__on_char {
 	my $t    = $_[1];
-	my $char = ord substr $t->{line}, $t->{line_cursor}, 1;
+	my $c = substr $t->{line}, $t->{line_cursor}, 1;
+	my $char = ord $c;
 
 	# Do we definitely know what something is?
 	return $COMMITMAP[$char]->__TOKENIZER__commit($t) if $COMMITMAP[$char];
@@ -407,9 +408,9 @@ sub __TOKENIZER__on_char {
 		}
 
 	} elsif ( $char >= 128 ) { # Outside ASCII
-		return 'PPI::Token::Word'->__TOKENIZER__commit($t) if $t =~ /\w/;
-		return 'Whitespace' if $t =~ /\s/;
-        }
+		return 'PPI::Token::Word'->__TOKENIZER__commit($t) if $c =~ /\w/;
+		return 'Whitespace' if $c =~ /\s/;
+	}
 
 
 	# All the whitespaces are covered, so what to do

--- a/lib/PPI/Token/Word.pm
+++ b/lib/PPI/Token/Word.pm
@@ -188,23 +188,25 @@ sub __TOKENIZER__on_char {
 		return $t->{class}->__TOKENIZER__commit( $t );
 	}
 
-	# Check for a quote like operator
 	my $word = $t->{token}->{content};
-	if ( $QUOTELIKE{$word} and ! $class->__TOKENIZER__literal($t, $word, $tokens) ) {
-		$t->{class} = $t->{token}->set_class( $QUOTELIKE{$word} );
-		return $t->{class}->__TOKENIZER__on_char( $t );
-	}
+	if ( $KEYWORDS{$word} ) {
+		# Check for a Perl keyword that is forced to be a normal word instead
+		if ( $t->__current_token_is_forced_word ) {
+			$t->{class} = $t->{token}->set_class( 'Word' );
+			return $t->{class}->__TOKENIZER__on_char( $t );
+		}
 
-	# Check for a Perl keyword that is forced to be a normal word instead
-	if ( $KEYWORDS{$word} and $class->__TOKENIZER__literal($t, $word, $tokens) ) {
-		$t->{class} = $t->{token}->set_class( 'Word' );
-		return $t->{class}->__TOKENIZER__on_char( $t );
-	}
+		# Check for a quote like operator. %QUOTELIKE must be subset of %KEYWORDS
+		if ( $QUOTELIKE{$word} ) {
+			$t->{class} = $t->{token}->set_class( $QUOTELIKE{$word} );
+			return $t->{class}->__TOKENIZER__on_char( $t );
+		}
 
-	# Or one of the word operators
-	if ( $OPERATOR{$word} and ! $class->__TOKENIZER__literal($t, $word, $tokens) ) {
-	 	$t->{class} = $t->{token}->set_class( 'Operator' );
- 		return $t->_finalize_token->__TOKENIZER__on_char( $t );
+		# Or one of the word operators. %OPERATOR must be subset of %KEYWORDS
+		if ( $OPERATOR{$word} ) {
+			$t->{class} = $t->{token}->set_class( 'Operator' );
+			return $t->_finalize_token->__TOKENIZER__on_char( $t );
+		}
 	}
 
 	# Unless this is a simple identifier, at this point
@@ -319,7 +321,7 @@ sub __TOKENIZER__commit {
 		# Since its not a simple identifier...
 		$token_class = 'Word';
 
-	} elsif ( $class->__TOKENIZER__literal($t, $word, $tokens) ) {
+	} elsif ( $KEYWORDS{$word} and $t->__current_token_is_forced_word ) {
 		$token_class = 'Word';
 
 	} elsif ( $QUOTELIKE{$word} ) {
@@ -367,45 +369,6 @@ sub __TOKENIZER__commit {
 		return 0;
 	}
 	$t->_finalize_token->__TOKENIZER__on_char($t);
-}
-
-# Is the word in a "forced" context, and thus cannot be either an
-# operator or a quote-like thing. This version is only useful
-# during tokenization.
-sub __TOKENIZER__literal {
-	my ($class, $t, $word, $tokens) = @_;
-
-	# Is this a forced-word context?
-	# i.e. Would normally be seen as an operator.
-	return '' if !$KEYWORDS{$word};
-
-	# Check the cases when we have previous tokens
-	pos $t->{line} = $t->{line_cursor};
-	if ( $tokens ) {
-		my $token = $tokens->[0] or return '';
-
-		# We are forced if we are a method name
-		return 1 if $token->{content} eq '->';
-
-		# We are forced if we are a sub name or a package name
-		return 1 if $token->isa('PPI::Token::Word') and
-			( $token->{content} eq 'sub' or $token->{content} eq 'package' );
-
-		# If we are contained in a pair of curly braces,
-		# we are probably a bareword hash key
-		if ( $token->{content} eq '{' and $t->{line} =~ /\G\s*\}/gc ) {
-			return 1;
-		}
-	}
-
-	# In addition, if the word is followed by => it is probably
-	# also actually a word and not a regex.
-	if ( $t->{line} =~ /\G\s*=>/gc ) {
-		return 1;
-	}
-
-	# Otherwise we probably aren't forced
-	'';
 }
 
 1;

--- a/lib/PPI/Token/_QuoteEngine/Full.pm
+++ b/lib/PPI/Token/_QuoteEngine/Full.pm
@@ -32,7 +32,7 @@ BEGIN {
 		's'   => { operator => 's',   braced => undef, separator => undef, _sections => 2, modifiers => 1 },
 		'tr'  => { operator => 'tr',  braced => undef, separator => undef, _sections => 2, modifiers => 1 },
 
-		# Y is the little used variant of tr
+		# Y is the little-used variant of tr
 		'y'   => { operator => 'y',   braced => undef, separator => undef, _sections => 2, modifiers => 1 },
 
 		'/'   => { operator => undef, braced => 0,     separator => '/',   _sections => 1, modifiers => 1 },

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -552,7 +552,7 @@ sub _process_next_char {
 	return 0 if ++$self->{line_cursor} >= $self->{line_length};
 
 	# Pass control to the token class
-        my $result;
+	my $result;
 	unless ( $result = $self->{class}->__TOKENIZER__on_char( $self ) ) {
 		# undef is error. 0 is "Did stuff ourself, you don't have to do anything"
 		return defined $result ? 1 : undef;

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -771,6 +771,55 @@ sub _current_x_is_operator {
 	;
 }
 
+
+# Assuming we are at the end of parsing the current token that could be a word,
+# a wordlike operator, or a version string, try to determine whether context
+# before or after it forces it to be a bareword. This method is only useful
+# during tokenization.
+sub __current_token_is_forced_word {
+	my ( $t ) = @_;
+
+	# Check if forced by preceding tokens.
+
+	my ( $prev, $prevprev ) = @{ $t->_previous_significant_tokens(2) };
+	if ( !$prev ) {
+		pos $t->{line} = $t->{line_cursor};
+	}
+	else {
+		my $content = $prev->{content};
+
+		# We are forced if we are a method name.
+		# '->' will always be an operator, so we don't check its type.
+		return 1 if $content eq '->';
+
+		# If we are contained in a pair of curly braces, we are probably a
+		# forced bareword hash key. '{' is never a word or operator, so we
+		# don't check its type.
+		pos $t->{line} = $t->{line_cursor};
+		return 1 if $content eq '{' and $t->{line} =~ /\G\s*\}/gc;
+
+		# We are forced if we are a sub name or a package name. 'sub' and
+		# 'package' will always be words, so we don't check their type. We're a
+		# forced package unless we're preceded by 'package sub', in which case
+		# we're a version string.
+		return ( !$prevprev || $prevprev->content ne 'package' ) if $content eq 'sub';
+
+		# We're a forced package unless we're preceded by 'package package', in
+		# which case we're a version string.
+		return ( !$prevprev || $prevprev->content ne 'package' )
+			if $content eq 'package';
+	}
+	# pos on $t->{line} is guaranteed to be set at this point.
+
+	# Check if forced by following tokens.
+
+	# If the word is followed by => it is probably a word, not a regex.
+	return 1 if $t->{line} =~ /\G\s*=>/gc;
+
+	# Otherwise we probably aren't forced
+	return '';
+}
+
 1;
 
 =pod

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -102,7 +102,35 @@ my %X_CAN_FOLLOW_OPERATOR = map { $_ => 1 } qw( -- ++ );
 # These are the exceptions.
 my %X_CAN_FOLLOW_STRUCTURE = map { $_ => 1 } qw( } ] \) );
 
-
+# Something that looks like the x operator but follows a word
+# is usually that word's argument. 
+# These are the exceptions.
+# chop, chomp, dump are ambiguous because they can have either parms
+# or no parms.
+my %X_CAN_FOLLOW_WORD = map { $_ => 1 } qw(
+		endgrent
+		endhostent
+		endnetent
+		endprotoent
+		endpwent
+		endservent
+		fork
+		getgrent
+		gethostent
+		getlogin
+		getnetent
+		getppid
+		getprotoent
+		getpwent
+		getservent
+		setgrent
+		setpwent
+		time
+		times
+		wait
+		wantarray
+		__SUB__
+);
 
 
 
@@ -771,6 +799,8 @@ sub _current_x_is_operator {
 		$prev
 		&& (!$prev->isa('PPI::Token::Operator') || $X_CAN_FOLLOW_OPERATOR{$prev})
 		&& (!$prev->isa('PPI::Token::Structure') || $X_CAN_FOLLOW_STRUCTURE{$prev})
+		&& (!$prev->isa('PPI::Token::Word') || $X_CAN_FOLLOW_WORD{$prev})
+		&& !$prev->isa('PPI::Token::Label')
 	;
 }
 

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -767,7 +767,7 @@ my %OBVIOUS_CONTENT = (
 
 my %USUALLY_FORCES = map { $_ => 1 } qw( sub package use no );
 
-# Try to determine operator/operand context, is possible.
+# Try to determine operator/operand context, if possible.
 # Returns "operator", "operand", or "" if unknown.
 sub _opcontext {
 	my $self   = shift;

--- a/t/01_compile.t
+++ b/t/01_compile.t
@@ -1,29 +1,12 @@
 #!/usr/bin/perl
 
-# Formal testing for PPI
-
 # This test script only tests that the tree compiles
 
-use strict;
-use File::Spec::Functions ':ALL';
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
-use Test::More tests => 19;
-use Test::NoWarnings;
+use t::lib::PPI::Test::pragmas;
+use Test::More tests => 18;
 
 
-
-
-
-# Check their perl version
-ok( $] >= 5.006, "Your perl is new enough" );
-
-# Does the module load
+# Do the modules load
 use_all_ok( qw{
 	PPI
 	PPI::Tokenizer

--- a/t/01_compile.t
+++ b/t/01_compile.t
@@ -3,7 +3,7 @@
 # This test script only tests that the tree compiles
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 18;
+use Test::More tests => 17 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 
 # Do the modules load

--- a/t/03_document.t
+++ b/t/03_document.t
@@ -2,47 +2,32 @@
 
 # PPI::Document tests
 
-use strict;
-use File::Spec::Functions ':ALL';
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-use PPI;
-
-# Execute the tests
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 14;
-use Test::NoWarnings;
 
-# Test file
-my $file  = catfile(qw{ t data 03_document test.dat  });
-my $empty = catfile(qw{ t data 03_document empty.dat });
-ok( -f $file,  'Found test file' );
-ok( -f $empty, 'Found test file' );
-
-# Test script
-my $script = <<'END_PERL';
-#!/usr/bin/perl
-
-# A simple test script
-
-print "Hello World!\n";
-END_PERL
-
-
-
+use File::Spec::Functions ':ALL';
+use PPI;
 
 
 #####################################################################
 # Test a basic document
 
 # Parse a simple document in all possible ways
-SCOPE: {
+NEW: {
+	my $file  = catfile(qw{ t data 03_document test.dat  });
+	ok( -f $file,  'Found test.dat' );
+
 	my $doc1 = PPI::Document->new( $file );
 	isa_ok( $doc1, 'PPI::Document' );
 
+	# Test script
+	my $script = <<'END_PERL';
+#!/usr/bin/perl
+
+# A simple test script
+
+print "Hello World!\n";
+END_PERL
 	my $doc2 = PPI::Document->new( \$script );
 	isa_ok( $doc2, 'PPI::Document' );
 
@@ -61,7 +46,10 @@ SCOPE: {
 }
 
 # Repeat the above with a null document
-SCOPE: {
+NEW_EMPTY: {
+	my $empty = catfile(qw{ t data 03_document empty.dat });
+	ok( -f $empty, 'Found empty.dat' );
+
 	my $doc1 = PPI::Document->new( $empty );
 	isa_ok( $doc1, 'PPI::Document' );
 

--- a/t/03_document.t
+++ b/t/03_document.t
@@ -3,7 +3,7 @@
 # PPI::Document tests
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 14;
+use Test::More tests => 13 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;

--- a/t/04_element.t
+++ b/t/04_element.t
@@ -5,20 +5,13 @@
 # This does an empiric test that when we try to parse something,
 # something ( anything ) comes out the other side.
 
-use strict;
-use File::Spec::Functions ':ALL';
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-use PPI::Lexer ();
-
-# Execute the tests
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 221;
-use Test::NoWarnings;
+
+use File::Spec::Functions ':ALL';
+use PPI;
 use Scalar::Util 'refaddr';
+
 
 sub is_object {
 	my ($left, $right, $message) = @_;

--- a/t/04_element.t
+++ b/t/04_element.t
@@ -6,7 +6,7 @@
 # something ( anything ) comes out the other side.
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 221;
+use Test::More tests => 220 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;

--- a/t/05_lexer.t
+++ b/t/05_lexer.t
@@ -1,36 +1,16 @@
 #!/usr/bin/perl
 
-# Compare a large number of specific constructs
-# with the expected Lexer dumps.
+# Compare a large number of specific code samples (.code)
+# with the expected Lexer dumps (.dump).
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-use PPI::Lexer;
-use PPI::Dumper;
-
-
-
-
-
-#####################################################################
-# Prepare
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 219;
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
+use PPI::Lexer;
 use t::lib::PPI;
-
-
-
-
 
 #####################################################################
 # Code/Dump Testing
-# ntests = 2 + 15 * nfiles
 
 t::lib::PPI->run_testdir( catdir( 't', 'data', '05_lexer' ) );

--- a/t/05_lexer.t
+++ b/t/05_lexer.t
@@ -4,7 +4,7 @@
 # with the expected Lexer dumps (.dump).
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 219;
+use Test::More tests => 218 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI::Lexer;

--- a/t/06_round_trip.t
+++ b/t/06_round_trip.t
@@ -3,19 +3,11 @@
 # Load ALL of the PPI files, lex them in, dump them
 # out, and verify that the code goes in and out cleanly.
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More; # Plan comes later
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
 use PPI;
-
-
 
 
 

--- a/t/06_round_trip.t
+++ b/t/06_round_trip.t
@@ -18,7 +18,7 @@ use PPI;
 my %tests = map { $_ => $INC{$_} } grep { ! /\bXS\.pm/ } grep { /^PPI\b/ } keys %INC;
 my @files = sort values %tests;
 unless ( @files ) {
-	Test::More::plan( tests => 2 );
+	Test::More::plan( tests => ($ENV{AUTHOR_TESTING} ? 1 : 0) + 1 );
 	ok( undef, "Failed to find any files to test" );
 	exit();
 }
@@ -40,7 +40,7 @@ foreach my $dir (
 push @files, find_files( 't' );
 
 # Declare our plan
-Test::More::plan( tests => 1 + scalar(@files) * 9 );
+Test::More::plan( tests => ($ENV{AUTHOR_TESTING} ? 1 : 0) + scalar(@files) * 9 );
 
 
 

--- a/t/07_token.t
+++ b/t/07_token.t
@@ -2,20 +2,12 @@
 
 # Formal unit tests for specific PPI::Token classes
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
-# Execute the tests
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 447;
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
-use t::lib::PPI;
 use PPI;
+use t::lib::PPI;
 
 
 
@@ -23,7 +15,6 @@ use PPI;
 
 #####################################################################
 # Code/Dump Testing
-# ntests = 2 + 12 * nfiles
 
 t::lib::PPI->run_testdir( catdir( 't', 'data', '07_token' ) );
 
@@ -33,7 +24,7 @@ t::lib::PPI->run_testdir( catdir( 't', 'data', '07_token' ) );
 
 #####################################################################
 # PPI::Token::Symbol Unit Tests
-# Note: braces and the symbol() method are tested in regression.t
+# Note: braces and the symbol() method are tested in 08_regression.t
 
 SCOPE: {
 	# Test both creation methods

--- a/t/07_token.t
+++ b/t/07_token.t
@@ -3,7 +3,7 @@
 # Formal unit tests for specific PPI::Token classes
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 447;
+use Test::More tests => 446 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;

--- a/t/08_regression.t
+++ b/t/08_regression.t
@@ -4,19 +4,11 @@
 
 # Some other regressions tests are included here for simplicity.
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
-# For each new item in t/data/08_regression add another 15 tests
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 932;
-use Test::NoWarnings;
-use t::lib::PPI;
+
 use PPI;
+use t::lib::PPI;
 
 sub pause {
 	local $@;
@@ -25,11 +17,8 @@ sub pause {
 
 
 
-
-
 #####################################################################
 # Code/Dump Testing
-# ntests = 2 + 14 * nfiles
 
 t::lib::PPI->run_testdir(qw{ t data 08_regression });
 

--- a/t/08_regression.t
+++ b/t/08_regression.t
@@ -5,7 +5,7 @@
 # Some other regressions tests are included here for simplicity.
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 932;
+use Test::More tests => 931 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 use t::lib::PPI;

--- a/t/09_normal.t
+++ b/t/09_normal.t
@@ -3,16 +3,9 @@
 # Testing of the normalization functions.
 # (only very basic at this point)
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 14;
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
 use PPI;
 

--- a/t/09_normal.t
+++ b/t/09_normal.t
@@ -4,7 +4,7 @@
 # (only very basic at this point)
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 14;
+use Test::More tests => 13 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;

--- a/t/10_statement.t
+++ b/t/10_statement.t
@@ -2,18 +2,10 @@
 
 # Test the various PPI::Statement packages
 
-use strict;
-BEGIN {
-	$| = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 6;
-use Test::NoWarnings;
-use PPI ();
+
+use PPI;
 
 
 

--- a/t/10_statement.t
+++ b/t/10_statement.t
@@ -4,47 +4,16 @@
 
 use strict;
 BEGIN {
-	no warnings 'once';
 	$| = 1;
+	$^W = 1;
+	no warnings 'once';
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
 
-# Execute the tests
-use Test::More tests => 12;
+use Test::More tests => 6;
 use Test::NoWarnings;
-use File::Spec::Functions ':ALL';
-use Scalar::Util 'refaddr';
-use PPI::Lexer ();
-
-
-
-
-
-#####################################################################
-# Tests for PPI::Statement::Package
-
-SCOPE: {
-	# Create a document with various example package statements
-	my $Document = PPI::Lexer->lex_source( <<'END_PERL' );
-package Foo;
-SCOPE: {
-	package # comment
-	Bar::Baz;
-	1;
-}
-1;
-END_PERL
-	isa_ok( $Document, 'PPI::Document' );
-
-	# Check that both of the package statements are detected
-	my $packages = $Document->find('Statement::Package');
-	is( scalar(@$packages), 2, 'Found 2 package statements' );
-	is( $packages->[0]->namespace, 'Foo', 'Package 1 returns correct namespace' );
-	is( $packages->[1]->namespace, 'Bar::Baz', 'Package 2 returns correct namespace' );
-	is( $packages->[0]->file_scoped, 1,  '->file_scoped returns true for package 1' );
-	is( $packages->[1]->file_scoped, '', '->file_scoped returns false for package 2' );
-}
+use PPI ();
 
 
 

--- a/t/10_statement.t
+++ b/t/10_statement.t
@@ -3,7 +3,7 @@
 # Test the various PPI::Statement packages
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 6;
+use Test::More tests => 5 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/11_util.t
+++ b/t/11_util.t
@@ -2,18 +2,10 @@
 
 # Test the PPI::Util package
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 13;
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
-use PPI::Lexer ();
 use PPI;
 use PPI::Util qw{_Document _slurp};
 

--- a/t/11_util.t
+++ b/t/11_util.t
@@ -3,7 +3,7 @@
 # Test the PPI::Util package
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 13;
+use Test::More tests => 12 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;

--- a/t/12_location.t
+++ b/t/12_location.t
@@ -2,18 +2,11 @@
 
 # Tests the accuracy and features for location functionality
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 683;
-use Test::NoWarnings;
-use File::Spec::Functions ':ALL';
+
 use PPI;
+
 
 my $test_source = <<'END_PERL';
 my $foo = 'bar';

--- a/t/12_location.t
+++ b/t/12_location.t
@@ -3,7 +3,7 @@
 # Tests the accuracy and features for location functionality
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 683;
+use Test::More tests => 682 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/13_data.t
+++ b/t/13_data.t
@@ -2,18 +2,12 @@
 
 # Tests functionality relating to __DATA__ sections of files
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 8;
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
 use PPI;
+
 
 my $module = catfile('t', 'data', '13_data', 'Foo.pm');
 ok( -f $module, 'Test file exists' );

--- a/t/13_data.t
+++ b/t/13_data.t
@@ -3,7 +3,7 @@
 # Tests functionality relating to __DATA__ sections of files
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 8;
+use Test::More tests => 7 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;

--- a/t/14_charsets.t
+++ b/t/14_charsets.t
@@ -1,14 +1,7 @@
 ﻿#!/usr/bin/perl
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More;
-
 BEGIN {
 	if ($] < 5.008007) {
 		Test::More->import( skip_all => "Unicode support requires perl 5.8.7" );
@@ -17,9 +10,7 @@ BEGIN {
 	plan( tests => 17 );
 }
 
-use Test::NoWarnings;
-use utf8;
-use File::Spec::Functions ':ALL';
+use utf8;  # perl version check above says this is okay
 use Params::Util qw{_INSTANCE};
 use PPI;
 

--- a/t/14_charsets.t
+++ b/t/14_charsets.t
@@ -7,7 +7,7 @@ BEGIN {
 		Test::More->import( skip_all => "Unicode support requires perl 5.8.7" );
 		exit(0);
 	}
-	plan( tests => 17 );
+	plan( tests => 16 + ($ENV{AUTHOR_TESTING} ? 1 : 0) );
 }
 
 use utf8;  # perl version check above says this is okay

--- a/t/15_transform.t
+++ b/t/15_transform.t
@@ -1,15 +1,8 @@
 #!/usr/bin/perl
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More 0.86 tests => 24;
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
 use File::Remove;
 use PPI;

--- a/t/15_transform.t
+++ b/t/15_transform.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use t::lib::PPI::Test::pragmas;
-use Test::More 0.86 tests => 24;
+use Test::More 0.86 tests => 23 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use File::Remove;

--- a/t/16_xml.t
+++ b/t/16_xml.t
@@ -1,16 +1,8 @@
 #!/usr/bin/perl
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More 0.86 tests => 17;
-use Test::NoWarnings;
-use File::Spec::Functions ':ALL';
+
 use PPI;
 
 

--- a/t/16_xml.t
+++ b/t/16_xml.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use t::lib::PPI::Test::pragmas;
-use Test::More 0.86 tests => 17;
+use Test::More 0.86 tests => 16 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/17_storable.t
+++ b/t/17_storable.t
@@ -2,14 +2,7 @@
 
 # Test compatibility with Storable
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More;
 BEGIN {
 	# Is Storable installed?
@@ -21,7 +14,6 @@ BEGIN {
 	}
 }
 
-use Test::NoWarnings;
 use Scalar::Util  'refaddr';
 use PPI;
 

--- a/t/17_storable.t
+++ b/t/17_storable.t
@@ -7,7 +7,7 @@ use Test::More;
 BEGIN {
 	# Is Storable installed?
 	if ( eval { require Storable; 1 } ) {
-		plan( tests => 10 );
+		plan( tests => 9 + ($ENV{AUTHOR_TESTING} ? 1 : 0) );
 	} else {
 		plan( 'skip_all' );
 		exit(0);

--- a/t/18_cache.t
+++ b/t/18_cache.t
@@ -1,23 +1,17 @@
 #!/usr/bin/perl
 
-# Test compatibility with Storable
+# Test PPI::Cache
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 43;
-use Test::NoWarnings;
+
 use File::Spec::Unix;
 use File::Spec::Functions ':ALL';
 use Scalar::Util  'refaddr';
 use File::Remove  ();
 use PPI::Document ();
 use PPI::Cache    ();
+use Test::SubCalls;
 
 use constant VMS  => !! ( $^O eq 'VMS' );
 use constant FILE => VMS ? 'File::Spec::Unix' : 'File::Spec';
@@ -107,10 +101,7 @@ isa_ok( PPI::Document->get_cache, 'PPI::Cache' );
 is( refaddr($Cache), refaddr(PPI::Document->get_cache),
 	'->get_cache returns the same cache object' );
 
-SKIP: {
-	skip("Test::SubCalls requires >= 5.6", 7 ) if $] < 5.006;
-	require Test::SubCalls;
-
+SCOPE: {
 	# Set the tracking on the Tokenizer constructor
 	ok( Test::SubCalls::sub_track( 'PPI::Tokenizer::new' ), 'Tracking calls to PPI::Tokenizer::new' );
 	Test::SubCalls::sub_calls( 'PPI::Tokenizer::new', 0 );
@@ -130,9 +121,7 @@ SKIP: {
 		'PPI::Document->new with cache enabled returns two identical objects' );
 }
 
-SKIP: {
-	skip("Test::SubCalls requires >= 5.6", 8 ) if $] < 5.006;
-
+SCOPE: {
 	# Done now, can we clear the cache?
 	is( PPI::Document->set_cache(undef), 1, '->set_cache(undef) returns true' );
 	is( PPI::Document->get_cache, undef,    '->get_cache returns undef' );

--- a/t/18_cache.t
+++ b/t/18_cache.t
@@ -3,7 +3,7 @@
 # Test PPI::Cache
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 43;
+use Test::More tests => 42 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Unix;
 use File::Spec::Functions ':ALL';

--- a/t/19_selftesting.t
+++ b/t/19_selftesting.t
@@ -5,16 +5,9 @@
 
 # Using PPI to analyse its own code at install-time? Fuck yeah! :)
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More; # Plan comes later
-use Test::NoWarnings;
+
 use Test::Object;
 use File::Spec::Functions ':ALL';
 use Params::Util qw{_CLASS _ARRAY _INSTANCE _IDENTIFIER};

--- a/t/19_selftesting.t
+++ b/t/19_selftesting.t
@@ -77,7 +77,7 @@ is_deeply( $bad, [ 'Bad::Class1', 'Bad::Class2', 'Bad::Class3', 'Bad::Class4' ],
 foreach my $file ( @files ) {
 	# MD5 the raw file
 	my $md5a = PPI::Util::md5hex_file($file);
-	like( $md5a, qr/^[0-9a-f]{32}\z/, 'md5hex_file ok' );
+	like( $md5a, qr/^[[:xdigit:]]{32}\z/, 'md5hex_file ok' );
 
 	# Load the file
 	my $Document = PPI::Document->new($file);

--- a/t/19_selftesting.t
+++ b/t/19_selftesting.t
@@ -27,7 +27,7 @@ use constant CI => 'Class::Inspector';
 # Find all of the files to be checked
 my %tests = map { $_ => $INC{$_} } grep { ! /\bXS\.pm/ } grep { /^PPI\b/ } keys %INC;
 unless ( %tests ) {
-	Test::More::plan( tests => 2 );
+	Test::More::plan( tests => 1 + ($ENV{AUTHOR_TESTING} ? 1 : 0) );
 	ok( undef, "Failed to find any files to test" );
 	exit();
 }
@@ -40,7 +40,7 @@ foreach my $dir ( '05_lexer', '08_regression', '11_util', '13_data', '15_transfo
 }
 
 # Declare our plan
-Test::More::plan( tests => scalar(@files) * 14 + 4 );
+Test::More::plan( tests => scalar(@files) * 14 + 3 + ($ENV{AUTHOR_TESTING} ? 1 : 0) );
 
 
 

--- a/t/20_tokenizer_regression.t
+++ b/t/20_tokenizer_regression.t
@@ -1,30 +1,12 @@
 #!/usr/bin/perl
 
-# code/dump-style regression tests for known lexing problems.
+# Regression tests for known tokenization problems.
 
-# Some other regressions tests are included here for simplicity.
+use t::lib::PPI::Test::pragmas;
+use Test::More; # Plan comes later
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
-use File::Spec::Functions ':ALL';
-
-use PPI::Lexer;
-use PPI::Dumper;
-use Carp 'croak';
 use Params::Util qw{_INSTANCE};
-
-sub pause {
-	local $@;
-	sleep 1 if !eval { require Time::HiRes; Time::HiRes::sleep(0.1); 1 };
-}
-
-
+use PPI;
 
 
 
@@ -61,15 +43,14 @@ BEGIN {
 		);
 }
 
-use Test::More tests => 1 + scalar(@FAILURES) * 3;
-use Test::NoWarnings;
+Test::More::plan( tests => 1 + scalar(@FAILURES) * 3 );
 
 
 
 
 
 #####################################################################
-# Code/Dump Testing
+# Test all the failures
 
 foreach my $code ( @FAILURES ) {
 	test_code( $code );
@@ -94,7 +75,7 @@ sub test_code {
 	my $code     = shift;
 	my $quotable = quotable($code);
 	my $Document = eval {
-		# $SIG{__WARN__} = sub { croak('Triggered a warning') };
+		# use Carp 'croak'; $SIG{__WARN__} = sub { croak('Triggered a warning') };
 		PPI::Document->new(\$code);
 	};
 	ok( _INSTANCE($Document, 'PPI::Document'),
@@ -117,7 +98,7 @@ sub test_code {
 sub quickcheck {
 	my $code       = shift;
 	my $fails      = $code;
-	# $SIG{__WARN__} = sub { croak('Triggered a warning') };
+	# use Carp 'croak'; $SIG{__WARN__} = sub { croak('Triggered a warning') };
 
 	while ( length $fails ) {
 		chop $code;

--- a/t/20_tokenizer_regression.t
+++ b/t/20_tokenizer_regression.t
@@ -43,7 +43,7 @@ BEGIN {
 		);
 }
 
-Test::More::plan( tests => 1 + scalar(@FAILURES) * 3 );
+Test::More::plan( tests => ($ENV{AUTHOR_TESTING} ? 1 : 0) + scalar(@FAILURES) * 3 );
 
 
 

--- a/t/21_exhaustive.t
+++ b/t/21_exhaustive.t
@@ -2,14 +2,11 @@
 
 # Exhaustively test all possible Perl programs to a particular length
 
-use strict;
-use Carp 'croak';
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
+use Test::More; # Plan comes later
+
+use Params::Util qw{_INSTANCE};
+use PPI;
 
 use vars qw{$MAX_CHARS $ITERATIONS $LENGTH @ALL_CHARS};
 BEGIN {
@@ -35,18 +32,7 @@ BEGIN {
 	#	);
 }
 
-
-
-
-
-#####################################################################
-# Prepare
-
 use Test::More tests => ($MAX_CHARS + $ITERATIONS + 3);
-use Test::NoWarnings;
-use File::Spec::Functions ':ALL';
-use Params::Util qw{_INSTANCE};
-use PPI;
 
 
 
@@ -147,7 +133,7 @@ sub test_code2 {
 sub test_code {
 	my $code      = shift;
 	my $Document  = eval {
-		# $SIG{__WARN__} = sub { croak('Triggered a warning') };
+		# use Carp 'croak'; $SIG{__WARN__} = sub { croak('Triggered a warning') };
 		PPI::Document->new(\$code);
 	};
 

--- a/t/21_exhaustive.t
+++ b/t/21_exhaustive.t
@@ -32,7 +32,7 @@ BEGIN {
 	#	);
 }
 
-use Test::More tests => ($MAX_CHARS + $ITERATIONS + 3);
+use Test::More tests => ($MAX_CHARS + $ITERATIONS + 2 + ($ENV{AUTHOR_TESTING} ? 1 : 0));
 
 
 

--- a/t/22_readonly.t
+++ b/t/22_readonly.t
@@ -2,17 +2,9 @@
 
 # Testing of readonly functionality
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 9;
-use Test::NoWarnings;
-use File::Spec::Functions ':ALL';
+
 use PPI::Document;
 
 

--- a/t/22_readonly.t
+++ b/t/22_readonly.t
@@ -3,7 +3,7 @@
 # Testing of readonly functionality
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 9;
+use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI::Document;
 

--- a/t/23_file.t
+++ b/t/23_file.t
@@ -2,16 +2,9 @@
 
 # Testing of PPI::Document::File
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 5;
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
 use PPI::Document::File;
 

--- a/t/23_file.t
+++ b/t/23_file.t
@@ -3,7 +3,7 @@
 # Testing of PPI::Document::File
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 5;
+use Test::More tests => 4 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI::Document::File;

--- a/t/24_v6.t
+++ b/t/24_v6.t
@@ -3,16 +3,9 @@
 # Regression test of a Perl 5 grammar that exploded
 # with a "98 subroutine recursion" error in 1.201
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 9;
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
 use PPI;
 

--- a/t/24_v6.t
+++ b/t/24_v6.t
@@ -4,7 +4,7 @@
 # with a "98 subroutine recursion" error in 1.201
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 9;
+use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;

--- a/t/25_increment.t
+++ b/t/25_increment.t
@@ -5,20 +5,10 @@
 # state between an empty document and the entire file to make sure
 # all of them parse as legal documents and don't crash the parser.
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 3876;
-use Test::NoWarnings;
-use File::Spec::Functions ':ALL';
-use Params::Util qw{_INSTANCE};
-use PPI::Lexer;
-use PPI::Dumper;
+
+use PPI;
 use t::lib::PPI;
 
 

--- a/t/25_increment.t
+++ b/t/25_increment.t
@@ -6,7 +6,7 @@
 # all of them parse as legal documents and don't crash the parser.
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 3876;
+use Test::More tests => 3875 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 use t::lib::PPI;

--- a/t/26_bom.t
+++ b/t/26_bom.t
@@ -1,16 +1,8 @@
 #!/usr/bin/perl
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
-# For each new item in t/data/08_regression add another 14 tests
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 21;
-use Test::NoWarnings;
+
 use t::lib::PPI;
 use PPI;
 
@@ -20,6 +12,5 @@ use PPI;
 
 #####################################################################
 # Code/Dump Testing
-# ntests = 2 + 14 * nfiles
 
 t::lib::PPI->run_testdir(qw{ t data 26_bom });

--- a/t/26_bom.t
+++ b/t/26_bom.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 21;
+use Test::More tests => 20 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use t::lib::PPI;
 use PPI;

--- a/t/27_complete.t
+++ b/t/27_complete.t
@@ -2,16 +2,9 @@
 
 # Testing for the PPI::Document ->complete method
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More;
-use Test::NoWarnings;
+
 use File::Spec::Functions ':ALL';
 use PPI;
 

--- a/t/27_complete.t
+++ b/t/27_complete.t
@@ -12,7 +12,7 @@ use PPI;
 # The letter after the number acts as a boolean yes/no answer to
 # "Is this code complete"
 my @files = find_files( catdir( 't', 'data', '27_complete' ) );
-my $tests = (scalar(@files) * 2) + 2;
+my $tests = (scalar(@files) * 2) + 1 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 plan( tests => $tests );
 
 

--- a/t/28_foreach_qw.t
+++ b/t/28_foreach_qw.t
@@ -2,17 +2,10 @@
 
 # Standalone tests to check "foreach qw{foo} {}"
 
-use strict;
-BEGIN {
-	no warnings 'once';
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 13;
-use Test::NoWarnings;
-use File::Spec::Functions ':ALL';
+
+#use File::Spec::Functions ':ALL';
 use PPI;
 
 

--- a/t/28_foreach_qw.t
+++ b/t/28_foreach_qw.t
@@ -3,7 +3,7 @@
 # Standalone tests to check "foreach qw{foo} {}"
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 13;
+use Test::More tests => 12 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 #use File::Spec::Functions ':ALL';
 use PPI;

--- a/t/interactive.t
+++ b/t/interactive.t
@@ -1,20 +1,14 @@
 #!/usr/bin/perl
 
 # Script used to temporarily test the most recent parser bug.
-# Testing it here is must more efficient than having to trace
+# Testing it here is much more efficient than having to trace
 # down through the entire set of regression tests.
 
-use strict;
-use File::Spec::Functions ':ALL';
-BEGIN {
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::XS_DISABLE = 1; # Prevent warning
-}
+use t::lib::PPI::Test::pragmas;
+use Test::More tests => 3;
+
 use PPI;
 
-# Execute the tests
-use Test::More tests => 2;
 
 # Define the test code
 my $code = 'sub f:f(';

--- a/t/interactive.t
+++ b/t/interactive.t
@@ -5,7 +5,7 @@
 # down through the entire set of regression tests.
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 3;
+use Test::More tests => 2 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/lib/PPI/Test/pragmas.pm
+++ b/t/lib/PPI/Test/pragmas.pm
@@ -1,0 +1,33 @@
+package t::lib::PPI::Test::pragmas;
+
+=head1 NAME
+
+PPI::Test::pragmas -- standard complier/runtime setup for PPI tests
+
+=cut
+
+use 5.006;
+use strict;
+use warnings;
+
+use Test::NoWarnings;
+
+BEGIN {
+	select STDERR;  ## no critic ( InputOutput::ProhibitOneArgSelect )
+	$| = 1;
+	select STDOUT;  ## no critic ( InputOutput::ProhibitOneArgSelect )
+
+	no warnings 'once';  ## no critic ( TestingAndDebugging::ProhibitNoWarnings )
+	$PPI::XS_DISABLE = 1;
+	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
+}
+
+sub import {
+	strict->import();
+	warnings->import();
+	Test::NoWarnings->import();
+	return;
+}
+
+
+1;

--- a/t/lib/PPI/Test/pragmas.pm
+++ b/t/lib/PPI/Test/pragmas.pm
@@ -10,7 +10,8 @@ use 5.006;
 use strict;
 use warnings;
 
-use Test::NoWarnings;
+use Test::More 0.88;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings', ':no_end_test';
 
 BEGIN {
 	select STDERR;  ## no critic ( InputOutput::ProhibitOneArgSelect )
@@ -25,9 +26,11 @@ BEGIN {
 sub import {
 	strict->import();
 	warnings->import();
-	Test::NoWarnings->import();
 	return;
 }
 
+END {
+    Test::Warnings::had_no_warnings() if $ENV{AUTHOR_TESTING};
+}
 
 1;

--- a/t/ppi_element.t
+++ b/t/ppi_element.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Element
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 58;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_element.t
+++ b/t/ppi_element.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Element
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 58;
+use Test::More tests => 57 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_lexer.t
+++ b/t/ppi_lexer.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Lexer
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 44;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_lexer.t
+++ b/t/ppi_lexer.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Lexer
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 44;
+use Test::More tests => 43 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_node.t
+++ b/t/ppi_node.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Node
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 3;
-use Test::NoWarnings;
+
 use PPI;
 
 
@@ -19,6 +12,7 @@ PRUNE: {
 	# Avoids a bug in old Perls relating to the detection of scripts
 	# Known to occur in ActivePerl 5.6.1 and at least one 5.6.2 install.
 	my $hashbang = reverse 'lrep/nib/rsu/!#'; 
+
 	my $document = PPI::Document->new( \<<"END_PERL" );
 $hashbang
 

--- a/t/ppi_node.t
+++ b/t/ppi_node.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Node
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 3;
+use Test::More tests => 2 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_normal.t
+++ b/t/ppi_normal.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Normal
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 28;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_normal.t
+++ b/t/ppi_normal.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Normal
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 28;
+use Test::More tests => 27 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_statement.t
+++ b/t/ppi_statement.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Statement
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 23;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_statement.t
+++ b/t/ppi_statement.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Statement
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 23;
+use Test::More tests => 22 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_statement_compound.t
+++ b/t/ppi_statement_compound.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Statement::Compound
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 53;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_statement_compound.t
+++ b/t/ppi_statement_compound.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Statement::Compound
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 53;
+use Test::More tests => 52 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_statement_include.t
+++ b/t/ppi_statement_include.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Statement::Include
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 12066;
+use Test::More tests => 12065 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_statement_include.t
+++ b/t/ppi_statement_include.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Statement::Include
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 12066;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -10,7 +10,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 129;
+use Test::More tests => 14829;
 use Test::NoWarnings;
 use PPI;
 
@@ -62,8 +62,16 @@ END_PERL
 
 PERL_5_12_SYNTAX: {
 	my @names = (
-		'Foo',
-		'package',
+		'Foo',  # normal name
+		# Keywords must parse as Word and not influence lexing
+		# of subsequent curly braces.
+		keys %PPI::Token::Word::KEYWORDS,
+		# Other weird and/or special words
+		'__PACKAGE__',
+		'__FILE__',
+		'__LINE__',
+		'__SUB__',
+		'AUTOLOAD',
 	);
 	my @versions = (
 		[ 'v1.2.3 ', 'PPI::Token::Number::Version' ],

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -81,11 +81,11 @@ PERL_5_12_SYNTAX: {
 		[ 'v1.2.3', 'PPI::Token::Number::Version' ],
 		[ '0.50 ', 'PPI::Token::Number::Float' ],
 		[ '0.50', 'PPI::Token::Number::Float' ],
-		[ '', '' ],  # omit version
+		[ '', '' ],  # omit version, traditional
 	);
 	my @blocks = (
-		[ ';', 'PPI::Token::Structure' ],
-		[ '{ 1 }', 'PPI::Structure::Block' ],
+		[ ';', 'PPI::Token::Structure' ],  # traditional package syntax
+		[ '{ 1 }', 'PPI::Structure::Block' ],  # 5.12 package syntax
 	);
 	$_->[2] = strip_ws_padding( $_->[0] ) for @versions, @blocks;
 

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Statement::Package
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 14949;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -10,7 +10,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 14889;
+use Test::More tests => 14949;
 use Test::NoWarnings;
 use PPI;
 
@@ -69,6 +69,8 @@ PERL_5_12_SYNTAX: {
 		keys %PPI::Token::Word::KEYWORDS,
 		# regression: misparsed as version string
 		'v10',
+		# regression GitHub #122: 'x' parsed as x operator
+		'x64',
 		# Other weird and/or special words, just in case
 		'__PACKAGE__',
 		'__FILE__',

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -10,7 +10,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 14829;
+use Test::More tests => 14889;
 use Test::NoWarnings;
 use PPI;
 
@@ -62,11 +62,14 @@ END_PERL
 
 PERL_5_12_SYNTAX: {
 	my @names = (
-		'Foo',  # normal name
+		# normal name
+		'Foo',
 		# Keywords must parse as Word and not influence lexing
 		# of subsequent curly braces.
 		keys %PPI::Token::Word::KEYWORDS,
-		# Other weird and/or special words
+		# regression: misparsed as version string
+		'v10',
+		# Other weird and/or special words, just in case
 		'__PACKAGE__',
 		'__FILE__',
 		'__LINE__',

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -10,7 +10,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 3;
+use Test::More tests => 129;
 use Test::NoWarnings;
 use PPI;
 
@@ -34,4 +34,99 @@ END_PERL
 		diag 'Package statements found:';
 		diag $_->parent()->parent()->content() foreach @{$packages};
 	}
+}
+
+
+INSIDE_SCOPE: {
+	# Create a document with various example package statements
+	my $Document = PPI::Document->new( \<<'END_PERL' );
+package Foo;
+SCOPE: {
+	package # comment
+	Bar::Baz;
+	1;
+}
+1;
+END_PERL
+	isa_ok( $Document, 'PPI::Document' );
+
+	# Check that both of the package statements are detected
+	my $packages = $Document->find('Statement::Package');
+	is( scalar(@$packages), 2, 'Found 2 package statements' );
+	is( $packages->[0]->namespace, 'Foo', 'Package 1 returns correct namespace' );
+	is( $packages->[1]->namespace, 'Bar::Baz', 'Package 2 returns correct namespace' );
+	is( $packages->[0]->file_scoped, 1,  '->file_scoped returns true for package 1' );
+	is( $packages->[1]->file_scoped, '', '->file_scoped returns false for package 2' );
+}
+
+
+PERL_5_12_SYNTAX: {
+	my @names = (
+		'Foo',
+		'package',
+	);
+	my @versions = (
+		[ 'v1.2.3 ', 'PPI::Token::Number::Version' ],
+		[ 'v1.2.3', 'PPI::Token::Number::Version' ],
+		[ '0.50 ', 'PPI::Token::Number::Float' ],
+		[ '0.50', 'PPI::Token::Number::Float' ],
+		[ '', '' ],  # omit version
+	);
+	my @blocks = (
+		[ ';', 'PPI::Token::Structure' ],
+		[ '{ 1 }', 'PPI::Structure::Block' ],
+	);
+	$_->[2] = strip_ws_padding( $_->[0] ) for @versions, @blocks;
+
+	for my $name ( @names ) {
+		for my $version_pair ( @versions ) {
+			for my $block_pair ( @blocks ) {
+				my @test = prepare_package_test( $version_pair, $block_pair, $name );
+				test_package_blocks( @test );
+			}
+		}
+	}
+}
+
+sub strip_ws_padding {
+	my ( $string ) = @_;
+	$string =~ s/(^\s+|\s+$)//g;
+	return $string;
+}
+
+sub prepare_package_test {
+	my ( $version_pair, $block_pair, $name ) = @_;
+
+	my ( $version, $version_type, $version_stripped ) = @{$version_pair};
+	my ( $block, $block_type, $block_stripped ) = @{$block_pair};
+
+	my $code = "package $name $version$block";
+
+	my $expected_package_tokens = [
+		[ 'PPI::Token::Word', 'package' ],
+		[ 'PPI::Token::Word', $name ],
+		($version ne '') ? [ $version_type, $version_stripped ] : (),
+		[ $block_type, $block_stripped ],
+	];
+
+	return ( $code, $expected_package_tokens );
+}
+
+sub test_package_blocks {
+	my ( $code, $expected_package_tokens ) = @_;
+
+	my $Document = PPI::Document->new( \"$code 999;" );
+	is(     $Document->schildren, 2, "$code number of statements in document" );
+	isa_ok( $Document->schild(0), 'PPI::Statement::Package', $code );
+
+	# first child is the package statement
+	my $got_tokens = [ map { [ ref $_, "$_" ] } $Document->schild(0)->schildren ];
+	is_deeply( $got_tokens, $expected_package_tokens, "$code tokens as expected" );
+
+	# second child not swallowed up by the first
+	isa_ok( $Document->schild(1), 'PPI::Statement', "$code prior statement end recognized" );
+	isa_ok( $Document->schild(1)->schild(0), 'PPI::Token::Number', $code );
+	is(     $Document->schild(1)->schild(0), '999', "$code number correct"  );
+
+	return;
 }

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Statement::Package
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 14949;
+use Test::More tests => 14948 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_statement_scheduled.t
+++ b/t/ppi_statement_scheduled.t
@@ -2,18 +2,11 @@
 
 # Test PPI::Statement::Scheduled
 
-use strict;
-
-BEGIN {
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 241;
-use Test::NoWarnings;
+
 use PPI;
+
 
 SUB_WORD_OPTIONAL: {
 	for my $name ( qw( BEGIN CHECK UNITCHECK INIT END ) ) {

--- a/t/ppi_statement_scheduled.t
+++ b/t/ppi_statement_scheduled.t
@@ -3,7 +3,7 @@
 # Test PPI::Statement::Scheduled
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 241;
+use Test::More tests => 240 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_statement_sub.t
+++ b/t/ppi_statement_sub.t
@@ -3,7 +3,6 @@
 # Test PPI::Statement::Sub
 
 use strict;
-
 BEGIN {
 	$^W = 1;
 	no warnings 'once';
@@ -11,7 +10,7 @@ BEGIN {
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
 
-use Test::More tests => 131;
+use Test::More tests => 6083;
 use Test::NoWarnings;
 use PPI;
 
@@ -89,6 +88,78 @@ sub test_sub_as {
 	else {
 		ok( !$sub_statement->block, "$code: has no block" );
 	}
+
+	return;
+}
+
+KEYWORDS_AS_SUB_NAMES: {
+	my @names = (
+		# normal name
+		'foo',
+		# Keywords must parse as Word and not influence lexing
+		# of subsequent curly braces.
+		keys %PPI::Token::Word::KEYWORDS,
+		# regression: misparsed as version string
+		'v10',
+		# Other weird and/or special words, just in case
+		'__PACKAGE__',
+		'__FILE__',
+		'__LINE__',
+		'__SUB__',
+		'AUTOLOAD',
+	);
+	my @blocks = (
+		[ ';', 'PPI::Token::Structure' ],
+		[ ' ;', 'PPI::Token::Structure' ],
+		[ '{ 1 }', 'PPI::Structure::Block' ],
+		[ ' { 1 }', 'PPI::Structure::Block' ],
+	);
+	$_->[2] = strip_ws_padding( $_->[0] ) for @blocks;
+
+	for my $name ( @names ) {
+		for my $block_pair ( @blocks ) {
+			my @test = prepare_sub_test( $block_pair, $name );
+			test_subs( @test );
+		}
+	}
+}
+
+sub strip_ws_padding {
+	my ( $string ) = @_;
+	$string =~ s/(^\s+|\s+$)//g;
+	return $string;
+}
+
+sub prepare_sub_test {
+	my ( $block_pair, $name ) = @_;
+
+	my ( $block, $block_type, $block_stripped ) = @{$block_pair};
+
+	my $code = "sub $name $block";
+
+	my $expected_sub_tokens = [
+		[ 'PPI::Token::Word', 'sub' ],
+		[ 'PPI::Token::Word', $name ],
+		[ $block_type, $block_stripped ],
+	];
+
+	return ( $code, $expected_sub_tokens );
+}
+
+sub test_subs {
+	my ( $code, $expected_sub_tokens ) = @_;
+
+	my $Document = PPI::Document->new( \"$code 999;" );
+	is(     $Document->schildren, 2, "$code number of statements in document" );
+	isa_ok( $Document->schild(0), 'PPI::Statement::Sub', $code );
+
+	my $got_tokens = [ map { [ ref $_, "$_" ] } $Document->schild(0)->schildren ];
+	is_deeply( $got_tokens, $expected_sub_tokens, "$code tokens as expected" );
+
+	# second child not swallowed up by the first
+	isa_ok( $Document->schild(1), 'PPI::Statement', "$code prior statement end recognized" );
+	isa_ok( $Document->schild(1)->schild(0), 'PPI::Token::Number', $code );
+	is(     $Document->schild(1)->schild(0), '999', "$code number correct"  );
 
 	return;
 }

--- a/t/ppi_statement_sub.t
+++ b/t/ppi_statement_sub.t
@@ -2,16 +2,9 @@
 
 # Test PPI::Statement::Sub
 
-use strict;
-BEGIN {
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 6208;
-use Test::NoWarnings;
+
 use PPI;
 
 NAME: {

--- a/t/ppi_statement_sub.t
+++ b/t/ppi_statement_sub.t
@@ -3,7 +3,7 @@
 # Test PPI::Statement::Sub
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 6208;
+use Test::More tests => 6207 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_statement_sub.t
+++ b/t/ppi_statement_sub.t
@@ -10,7 +10,7 @@ BEGIN {
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
 
-use Test::More tests => 6204;
+use Test::More tests => 6208;
 use Test::NoWarnings;
 use PPI;
 
@@ -28,6 +28,7 @@ NAME: {
 		{ code => 'sub baz : method lvalue{}', name => 'baz' },
 		{ code => 'sub baz : method:lvalue{}', name => 'baz' },
 		{ code => 'sub baz (*) : method : lvalue{}', name => 'baz' },
+		{ code => 'sub x64 {}',  name => 'x64' },  # should not be parsed as x operator
 	) {
 		my $code = $test->{code};
 		my $name = $test->{name};

--- a/t/ppi_statement_variable.t
+++ b/t/ppi_statement_variable.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Statement::Variable
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-use Test::More 'no_plan';
-use Test::NoWarnings;
+use t::lib::PPI::Test::pragmas;
+use Test::More tests => 18;
+
 use PPI;
 
 

--- a/t/ppi_statement_variable.t
+++ b/t/ppi_statement_variable.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Statement::Variable
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 18;
+use Test::More tests => 17 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token__quoteengine_full.t
+++ b/t/ppi_token__quoteengine_full.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::_QuoteEngine::Full
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 94;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token__quoteengine_full.t
+++ b/t/ppi_token__quoteengine_full.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::_QuoteEngine::Full
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 94;
+use Test::More tests => 93 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_dashedword.t
+++ b/t/ppi_token_dashedword.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::DashedWord
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 10;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_dashedword.t
+++ b/t/ppi_token_dashedword.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::DashedWord
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 10;
+use Test::More tests => 9 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_heredoc.t
+++ b/t/ppi_token_heredoc.t
@@ -1,0 +1,110 @@
+#!/usr/bin/perl
+
+# Unit testing for PPI::Token::HereDoc
+
+use strict;
+
+BEGIN {
+	$|  = 1;
+	$^W = 1;
+	no warnings 'once';
+	$PPI::XS_DISABLE = 1;
+	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
+}
+use Test::Deep;
+use Test::More;
+use Test::NoWarnings;
+use PPI;
+
+# List of tests to perform. Each test requires the following information:
+#     - 'name': the name of the test in the output.
+#     - 'content': the Perl string to parse using PPI.
+#     - 'expected': a hashref with the keys being property names on the
+#       PPI::Token::HereDoc object, and the values being the expected value of
+#       that property after the heredoc block has been parsed.
+my @tests = (
+
+	# Tests with a carriage return after the termination marker.
+	{
+		name     => 'Bareword terminator.',
+		content  => "my \$heredoc = <<HERE;\nLine 1\nLine 2\nHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+		},
+	},
+	{
+		name     => 'Single-quoted bareword terminator.',
+		content  => "my \$heredoc = <<'HERE';\nLine 1\nLine 2\nHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+		},
+	},
+	{
+		name     => 'Double-quoted bareword terminator.',
+		content  => "my \$heredoc = <<\"HERE\";\nLine 1\nLine 2\nHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+		},
+	},
+	{
+		name     => 'Command-quoted terminator.',
+		content  => "my \$heredoc = <<`HERE`;\nLine 1\nLine 2\nHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'command',
+		},
+	},
+	{
+		name     => 'Legacy escaped bareword terminator.',
+		content  => "my \$heredoc = <<\\HERE;\nLine 1\nLine 2\nHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+		},
+	},
+
+);
+
+plan tests => 1 + @tests;
+
+for my $test ( @tests ) {
+	subtest(
+		$test->{name},
+		sub {
+			plan tests => 6 + keys %{ $test->{expected} };
+
+			my $document = PPI::Document->new( \$test->{content} );
+			isa_ok( $document, 'PPI::Document' );
+
+			my $heredocs = $document->find( 'Token::HereDoc' );
+			is( ref $heredocs,     'ARRAY', 'Found heredocs.' );
+			is( scalar @$heredocs, 1,       'Found 1 heredoc block.' );
+
+			my $heredoc = $heredocs->[0];
+			isa_ok( $heredoc, 'PPI::Token::HereDoc' );
+			can_ok( $heredoc, 'heredoc' );
+
+			my @content = $heredoc->heredoc;
+			is_deeply(
+				\@content,
+				[ "Line 1\n", "Line 2\n", ],
+				'The returned content does not include the heredoc terminator.',
+			) or diag "heredoc() returned ", explain \@content;
+
+			is( $heredoc->{$_}, $test->{expected}{$_}, "property '$_'" ) for keys %{ $test->{expected} };
+		}
+	);
+}

--- a/t/ppi_token_heredoc.t
+++ b/t/ppi_token_heredoc.t
@@ -2,19 +2,11 @@
 
 # Unit testing for PPI::Token::HereDoc
 
-use strict;
+use t::lib::PPI::Test::pragmas;
+use Test::More tests => 12;
 
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
-use Test::Deep;
-use Test::More;
-use Test::NoWarnings;
 use PPI;
+use Test::Deep;
 
 # List of tests to perform. Each test requires the following information:
 #     - 'name': the name of the test in the output.
@@ -141,8 +133,6 @@ my @tests = (
 	}
 
 );
-
-plan tests => 1 + @tests;
 
 for my $test ( @tests ) {
 	subtest(

--- a/t/ppi_token_heredoc.t
+++ b/t/ppi_token_heredoc.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::HereDoc
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 12;
+use Test::More tests => 11 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 use Test::Deep;

--- a/t/ppi_token_heredoc.t
+++ b/t/ppi_token_heredoc.t
@@ -76,6 +76,70 @@ my @tests = (
 		},
 	},
 
+	# Tests without a carriage return after the termination marker.
+	{
+		name     => 'Bareword terminator (no return).',
+		content  => "my \$heredoc = <<HERE;\nLine 1\nLine 2\nHERE",
+		expected => {
+			_terminator_line => 'HERE',
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+		},
+	},
+	{
+		name     => 'Single-quoted bareword terminator (no return).',
+		content  => "my \$heredoc = <<'HERE';\nLine 1\nLine 2\nHERE",
+		expected => {
+			_terminator_line => "HERE",
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+		},
+	},
+	{
+		name     => 'Double-quoted bareword terminator (no return).',
+		content  => "my \$heredoc = <<\"HERE\";\nLine 1\nLine 2\nHERE",
+		expected => {
+			_terminator_line => 'HERE',
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+		},
+	},
+	{
+		name     => 'Command-quoted terminator (no return).',
+		content  => "my \$heredoc = <<`HERE`;\nLine 1\nLine 2\nHERE",
+		expected => {
+			_terminator_line => 'HERE',
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'command',
+		},
+	},
+	{
+		name     => 'Legacy escaped bareword terminator (no return).',
+		content  => "my \$heredoc = <<\\HERE;\nLine 1\nLine 2\nHERE",
+		expected => {
+			_terminator_line => 'HERE',
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+		},
+	},
+
+	# Tests without a terminator.
+	{
+		name     => 'Unterminated heredoc block.',
+		content  => "my \$heredoc = <<HERE;\nLine 1\nLine 2\n",
+		expected => {
+			_terminator_line => undef,
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+		},
+	}
+
 );
 
 plan tests => 1 + @tests;

--- a/t/ppi_token_magic.t
+++ b/t/ppi_token_magic.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Magic
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 39;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_magic.t
+++ b/t/ppi_token_magic.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Magic
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 39;
+use Test::More tests => 38 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_number_version.t
+++ b/t/ppi_token_number_version.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Number::Version
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 736;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_number_version.t
+++ b/t/ppi_token_number_version.t
@@ -10,7 +10,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 10;
+use Test::More tests => 736;
 use Test::NoWarnings;
 use PPI;
 
@@ -28,4 +28,83 @@ LITERAL: {
 	is( length($literal1), 4, 'The literal length of doc1 is 4' );
 	is( length($literal2), 4, 'The literal length of doc1 is 4' );
 	is( $literal1, $literal2, 'Literals match for 1.2.3.4 vs v1.2.3.4' );
+}
+
+
+VSTRING_ENDS_CORRECTLY: {
+	my @tests = (
+		(
+			map {
+				{
+					desc=>"no . in 'v49$_', so not a version string",
+					code=>"v49$_",
+					expected=>[ 'PPI::Token::Word' => "v49$_" ],
+				}
+			} (
+				'x3', # not fooled by faux x operator with operand
+				'e10', # not fooled by faux scientific notation
+				keys %PPI::Token::Word::KEYWORDS,
+			),
+		),
+		(
+			map {
+				{
+					desc => "version string in 'v49.49$_' stops after number",
+					code => "v49.49$_",
+					expected => [
+						'PPI::Token::Number::Version' => 'v49.49',
+						get_class($_) => $_,
+					],
+				},
+			} (
+				keys %PPI::Token::Word::KEYWORDS,
+			),
+		),
+		(
+			map {
+				{
+					desc => "version string in '49.49.49$_' stops after number",
+					code => "49.49.49$_",
+					expected => [
+						'PPI::Token::Number::Version' => '49.49.49',
+						get_class($_) => $_,
+					],
+				},
+			} (
+				keys %PPI::Token::Word::KEYWORDS,
+			),
+		),
+		{
+			desc => 'version string, x, and operand',
+			code => 'v49.49.49x3',
+			expected => [
+				'PPI::Token::Number::Version' => 'v49.49.49',
+				'PPI::Token::Operator' => 'x',
+				'PPI::Token::Number' => '3',
+			],
+		},
+	);
+	for my $test ( @tests ) {
+		my $code = $test->{code};
+
+		my $d = PPI::Document->new( \$test->{code} );
+		my $tokens = $d->find( sub { 1; } );
+		$tokens = [ map { ref($_), $_->content() } @$tokens ];
+		my $expected = $test->{expected};
+		unshift @$expected, 'PPI::Statement', $test->{code};
+		my $ok = is_deeply( $tokens, $expected, $test->{desc} );
+		if ( !$ok ) {
+			diag "$test->{code} ($test->{desc})\n";
+			diag explain $tokens;
+			diag explain $test->{expected};
+		}
+	}
+}
+
+sub get_class {
+	my ( $t ) = @_;
+	my $ql = $PPI::Token::Word::QUOTELIKE{$t};
+	return "PPI::Token::$ql" if $ql;
+	return 'PPI::Token::Operator' if $PPI::Token::Word::OPERATOR{$t};
+	return 'PPI::Token::Word';
 }

--- a/t/ppi_token_number_version.t
+++ b/t/ppi_token_number_version.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Number::Version
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 736;
+use Test::More tests => 735 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Operator
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 1142;
+use Test::More tests => 1141 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -524,7 +524,7 @@ OPERATOR_FAT_COMMA: {
 				'PPI::Token::Word' => $_,
 				'PPI::Token::Operator' => '=>',
 				'PPI::Token::Number' => '2',
-		    ]
+			]
 		} } keys %PPI::Token::Word::KEYWORDS ),
 		( map { {
 			desc=>$_,
@@ -537,7 +537,7 @@ OPERATOR_FAT_COMMA: {
 				'PPI::Token::Operator' => '=>',
 				'PPI::Token::Number' => '2',
 				'PPI::Token::Structure' => ')',
-		    ]
+			]
 		} } keys %PPI::Token::Word::KEYWORDS ),
 		( map { {
 			desc=>$_,
@@ -550,7 +550,7 @@ OPERATOR_FAT_COMMA: {
 				'PPI::Token::Operator' => '=>',
 				'PPI::Token::Number' => '2',
 				'PPI::Token::Structure' => '}',
-		    ]
+			]
 		} } keys %PPI::Token::Word::KEYWORDS ),
 	);
 

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -13,7 +13,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 1141;
+use Test::More tests => 1142;
 use Test::NoWarnings;
 use PPI;
 
@@ -407,6 +407,17 @@ OPERATOR_X: {
 				'PPI::Token::Number' => '1',
 				'PPI::Token::Structure' => ';',
 				'PPI::Token::Structure' => '}',
+			]
+		},
+		{
+			desc => 'label plus x',
+			code => 'LABEL: x64',
+			expected => [
+				'PPI::Statement::Compound' => 'LABEL:',
+				'PPI::Token::Label' => 'LABEL:',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Statement' => 'x64',
+				'PPI::Token::Word' => 'x64',
 			]
 		},
 	);

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -13,7 +13,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 393;
+use Test::More tests => 1119;
 use Test::NoWarnings;
 use PPI;
 
@@ -465,6 +465,98 @@ OPERATOR_X: {
 	}
 
 	foreach my $test ( @tests ) {
+		my $d = PPI::Document->new( \$test->{code} );
+		my $tokens = $d->find( sub { 1; } );
+		$tokens = [ map { ref($_), $_->content() } @$tokens ];
+		my $expected = $test->{expected};
+		if ( $expected->[0] !~ /^PPI::Statement/ ) {
+			unshift @$expected, 'PPI::Statement', $test->{code};
+		}
+		my $ok = is_deeply( $tokens, $expected, $test->{desc} );
+		if ( !$ok ) {
+			diag "$test->{code} ($test->{desc})\n";
+			diag explain $tokens;
+			diag explain $test->{expected};
+		}
+	}
+}
+
+
+OPERATOR_FAT_COMMA: {
+	my @tests = (
+		{
+			desc => 'integer with integer',
+			code => '1 => 2',
+			expected => [
+				'PPI::Token::Number' => '1',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Operator' => '=>',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Number' => '2',
+			],
+		},
+		{
+			desc => 'word with integer',
+			code => 'foo => 2',
+			expected => [
+				'PPI::Token::Word' => 'foo',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Operator' => '=>',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Number' => '2',
+			],
+		},
+		{
+			desc => 'dashed word with integer',
+			code => '-foo => 2',
+			expected => [
+				'PPI::Token::Word' => '-foo',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Operator' => '=>',
+				'PPI::Token::Whitespace' => ' ',
+				'PPI::Token::Number' => '2',
+			],
+		},
+		( map { {
+			desc=>$_,
+			code=>"$_=>2",
+			expected=>[
+				'PPI::Token::Word' => $_,
+				'PPI::Token::Operator' => '=>',
+				'PPI::Token::Number' => '2',
+		    ]
+		} } keys %PPI::Token::Word::KEYWORDS ),
+		( map { {
+			desc=>$_,
+			code=>"($_=>2)",
+			expected=>[
+				'PPI::Structure::List' => "($_=>2)",
+				'PPI::Token::Structure' => '(',
+				'PPI::Statement::Expression' => "$_=>2",
+				'PPI::Token::Word' => $_,
+				'PPI::Token::Operator' => '=>',
+				'PPI::Token::Number' => '2',
+				'PPI::Token::Structure' => ')',
+		    ]
+		} } keys %PPI::Token::Word::KEYWORDS ),
+		( map { {
+			desc=>$_,
+			code=>"{$_=>2}",
+			expected=>[
+				'PPI::Structure::Constructor' => "{$_=>2}",
+				'PPI::Token::Structure' => '{',
+				'PPI::Statement::Expression' => "$_=>2",
+				'PPI::Token::Word' => $_,
+				'PPI::Token::Operator' => '=>',
+				'PPI::Token::Number' => '2',
+				'PPI::Token::Structure' => '}',
+		    ]
+		} } keys %PPI::Token::Word::KEYWORDS ),
+	);
+
+	for my $test ( @tests ) {
+		my $code = $test->{code};
+
 		my $d = PPI::Document->new( \$test->{code} );
 		my $tokens = $d->find( sub { 1; } );
 		$tokens = [ map { ref($_), $_->content() } @$tokens ];

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -13,7 +13,7 @@ BEGIN {
 	$PPI::XS_DISABLE = 1;
 	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
 }
-use Test::More tests => 398;
+use Test::More tests => 393;
 use Test::NoWarnings;
 use PPI;
 
@@ -30,20 +30,6 @@ FIND_ONE_OP: {
 	$ops = $doc->find( 'Token::Operator' );
 	is( ref $ops, 'ARRAY', "operator = found operators in number test" );
 	is( @$ops, 1, "operator = found exactly once in number test" );
-}
-
-
-HEREDOC: {
-	my $source = '$a = <<PERL_END;' . "\n" . 'PERL_END';
-	my $doc = PPI::Document->new( \$source );
-	isa_ok( $doc, 'PPI::Document', "parsed '$source'" );
-	my $ops = $doc->find( 'Token::HereDoc' );
-	is( ref $ops, 'ARRAY', "found heredoc" );
-	is( @$ops, 1, "heredoc found exactly once" );
-
-	$ops = $doc->find( 'Token::Operator' );
-	is( ref $ops, 'ARRAY', "operator = found operators in heredoc test" );
-	is( @$ops, 1, "operator = found exactly once in heredoc test" );
 }
 
 

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -2,19 +2,9 @@
 
 # Unit testing for PPI::Token::Operator
 
-use strict;
-BEGIN {
-	$|  = 1;
-	select STDERR;
-	$| = 1;
-	select STDOUT;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 1142;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_pod.t
+++ b/t/ppi_token_pod.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Pod
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 9;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_pod.t
+++ b/t/ppi_token_pod.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Pod
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 9;
+use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_prototype.t
+++ b/t/ppi_token_prototype.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Prototype
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 801;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_prototype.t
+++ b/t/ppi_token_prototype.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Prototype
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 801;
+use Test::More tests => 800 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_quote.t
+++ b/t/ppi_token_quote.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Quote
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 16;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_quote.t
+++ b/t/ppi_token_quote.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Quote
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 16;
+use Test::More tests => 15 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_quote_double.t
+++ b/t/ppi_token_quote_double.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Quote::Double
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 20;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_quote_double.t
+++ b/t/ppi_token_quote_double.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Quote::Double
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 20;
+use Test::More tests => 19 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_quote_interpolate.t
+++ b/t/ppi_token_quote_interpolate.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Quote::Interpolate
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 9;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_quote_interpolate.t
+++ b/t/ppi_token_quote_interpolate.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Quote::Interpolate
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 9;
+use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_quote_literal.t
+++ b/t/ppi_token_quote_literal.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Quote::Literal
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 13;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_quote_literal.t
+++ b/t/ppi_token_quote_literal.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Quote::Literal
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 13;
+use Test::More tests => 12 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_quote_single.t
+++ b/t/ppi_token_quote_single.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Quote::Single
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 25;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_quote_single.t
+++ b/t/ppi_token_quote_single.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Quote::Single
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 25;
+use Test::More tests => 24 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_quotelike_words.t
+++ b/t/ppi_token_quotelike_words.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::QuoteLike::Words
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 13;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_quotelike_words.t
+++ b/t/ppi_token_quotelike_words.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::QuoteLike::Words
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 1381;
+use Test::More tests => 1941;
 use Test::Deep;
 
 use PPI;
@@ -52,13 +52,38 @@ LITERAL: {
 
 	my $bs = '\\'; # a single backslash character
 
+	# escaped opening and closing
+	permute_test ["$bs)"],   '(', ')', [')'];
+	permute_test ["$bs("],   '(', ')', ['('];
+	permute_test ["$bs}"],   '{', '}', ['}'];
+	permute_test ["${bs}{"], '{', '}', ['{'];
+	permute_test ["$bs]"],   '[', ']', [']'];
+	permute_test ["${bs}["], '[', ']', ['['];
+	permute_test ["$bs<"],   '<', '>', ['<'];
+	permute_test ["$bs>"],   '<', '>', ['>'];
+	permute_test ["$bs/"],   '/', '/', ['/'];
+	permute_test ["$bs'"],   "'", "'", ["'"];
+	permute_test [$bs.'"'],  '"', '"', ['"'];
+
+	# alphanum delims have to be separated from qw
+	assemble_and_run " ",  ['a', "${bs}1"], '1', " ",  " ",  '1', ['a', '1'];
+	assemble_and_run " ",  ["${bs}a"],      'a', " ",  " ",  'a', ['a'];
+	assemble_and_run "\n", ["${bs}a"],      'a', "\n", "\n", 'a', ['a'];
+
 	# '#' delims cannot be separated from qw
 	assemble_and_run '',  ['a'],      '#', '',   ' ',  '#', ['a'];
 	assemble_and_run '',  ['a'],      '#', ' ',  ' ',  '#', ['a'];
+	assemble_and_run '',  ["$bs#"],   '#', '',   ' ',  '#', ['#'];
+	assemble_and_run '',  ["$bs#"],   '#', ' ',  ' ',  '#', ['#'];
+	assemble_and_run '',  ["$bs#"],   '#', "\n", "\n", '#', ['#'];
 
 	# a single backslash represents itself
 	assemble_and_run '',  [$bs],  '(', ' ',  ' ', ')', [$bs];
 	assemble_and_run '',  [$bs],  '(', "\n", ' ', ')', [$bs];
+
+	# a double backslash represents itself
+	assemble_and_run '',  ["$bs$bs"],  '(', ' ',  ' ', ')', [$bs];
+	assemble_and_run '',  ["$bs$bs"],  '(', "\n", ' ', ')', [$bs];
 
 	# even backslash can be a delimiter, in when it is, backslashes
 	# can't be embedded or escaped.

--- a/t/ppi_token_quotelike_words.t
+++ b/t/ppi_token_quotelike_words.t
@@ -3,48 +3,111 @@
 # Unit testing for PPI::Token::QuoteLike::Words
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 13;
+use Test::More tests => 1381;
+use Test::Deep;
 
 use PPI;
 
+sub permute_test;
+sub assemble_and_run;
 
 LITERAL: {
-	my $empty_list_document = PPI::Document->new(\<<'END_PERL');
-qw//
-qw/    /
-END_PERL
+	# empty
+	permute_test [], '/', '/', [];
+	permute_test [], '"', '"', [];
+	permute_test [], "'", "'", [];
+	permute_test [], '(', ')', [];
+	permute_test [], '{', '}', [];
+	permute_test [], '[', ']', [];
+	permute_test [], '<', '>', [];
 
-	isa_ok( $empty_list_document, 'PPI::Document' );
-	my $empty_list_tokens =
-		$empty_list_document->find('PPI::Token::QuoteLike::Words');
-	is( scalar @{$empty_list_tokens}, 2, 'Found expected empty word lists.' );
-	foreach my $token ( @{$empty_list_tokens} ) {
-		my @literal = $token->literal;
-		is( scalar @literal, 0, qq<No elements for "$token"> );
-	}
+	# words
+	permute_test ['a', 'b', 'c'],      '/', '/', ['a', 'b', 'c'];
+	permute_test ['a,', 'b', 'c,'],    '/', '/', ['a,', 'b', 'c,'];
+	permute_test ['a', ',', '#', 'c'], '/', '/', ['a', ',', '#', 'c'];
+	permute_test ['f_oo', 'b_ar'],     '/', '/', ['f_oo', 'b_ar'];
 
-	my $non_empty_list_document = PPI::Document->new(\<<'END_PERL');
-qw/foo bar baz/
-qw/  foo bar baz  /
-qw {foo bar baz}
-END_PERL
-	my @expected = qw/ foo bar baz /;
+	# it's allowed for both delims to be closers
+	permute_test ['a'], ')', ')', ['a'];
+	permute_test ['a'], '}', '}', ['a'];
+	permute_test ['a'], ']', ']', ['a'];
+	permute_test ['a'], '>', '>', ['a'];
 
-	isa_ok( $non_empty_list_document, 'PPI::Document' );
-	my $non_empty_list_tokens =
-		$non_empty_list_document->find('PPI::Token::QuoteLike::Words');
-	is(
-		scalar(@$non_empty_list_tokens),
-		3,
-		'Found expected non-empty word lists.',
-	);
-	foreach my $token ( @$non_empty_list_tokens ) {
-		my $literal = $token->literal;
-		is(
-			$literal,
-			scalar @expected,
-			qq<Scalar context literal() returns the list for "$token">,
-		);
-		is_deeply( [ $token->literal ], \@expected, '->literal matches expected' );
-	}
+	# containing things that sometimes are delimiters
+	permute_test ['/'],        '(', ')', ['/'];
+	permute_test ['//'],       '(', ')', ['//'];
+	permute_test ['qw()'],     '(', ')', ['qw()'];
+	permute_test ['qw', '()'], '(', ')', ['qw', '()'];
+	permute_test ['qw//'],     '(', ')', ['qw//'];
+
+	# nested delimiters
+	permute_test ['()'],           '(', ')', ['()'];
+	permute_test ['{}'],           '{', '}', ['{}'];
+	permute_test ['[]'],           '[', ']', ['[]'];
+	permute_test ['<>'],           '<', '>', ['<>'];
+	permute_test ['((', ')', ')'], '(', ')', ['((', ')', ')'];
+	permute_test ['{{', '}', '}'], '{', '}', ['{{', '}', '}'];
+	permute_test ['[[', ']', ']'], '[', ']', ['[[', ']', ']'];
+	permute_test ['<<', '>', '>'], '<', '>', ['<<', '>', '>'];
+
+	my $bs = '\\'; # a single backslash character
+
+	# '#' delims cannot be separated from qw
+	assemble_and_run '',  ['a'],      '#', '',   ' ',  '#', ['a'];
+	assemble_and_run '',  ['a'],      '#', ' ',  ' ',  '#', ['a'];
+
+	# a single backslash represents itself
+	assemble_and_run '',  [$bs],  '(', ' ',  ' ', ')', [$bs];
+	assemble_and_run '',  [$bs],  '(', "\n", ' ', ')', [$bs];
+
+	# even backslash can be a delimiter, in when it is, backslashes
+	# can't be embedded or escaped.
+	assemble_and_run '',   [],    $bs, ' ',  ' ',  $bs, [];
+	assemble_and_run '',   [],    $bs, "\n", "\n", $bs, [];
+	assemble_and_run '',   ['a'], $bs, '',   ' ',  $bs, ['a'];
+	assemble_and_run ' ',  ['a'], $bs, '',   ' ',  $bs, ['a'];
+	assemble_and_run "\n", ['a'], $bs, '',   ' ',  $bs, ['a'];
+}
+
+sub execute_test {
+	my ( $code, $expected, $msg ) = @_;
+
+	my $d = PPI::Document->new( \$code );
+	isa_ok( $d, 'PPI::Document', $msg );
+	my $found = $d->find( 'PPI::Token::QuoteLike::Words' ) || [];
+	is( @$found, 1, "$msg - exactly one qw" );
+	is( $found->[0]->content, $code, "$msg content()" );
+	is_deeply( [ $found->[0]->literal ], $expected, "$msg literal()"  );
+
+	return;
+}
+
+sub assemble_and_run {
+	my ( $pre_left_delim, $words_in, $left_delim, $delim_padding, $word_separator, $right_delim, $expected ) = @_;
+
+	my $code = "qw$pre_left_delim$left_delim$delim_padding" . join(' ', @$words_in) . "$delim_padding$right_delim";
+	execute_test $code, $expected, $code;
+
+	return;
+}
+
+sub permute_test {
+	my ( $words_in, $left_delim, $right_delim, $expected ) = @_;
+
+	assemble_and_run "",  $words_in, $left_delim, "", " ",  $right_delim, $expected;
+	assemble_and_run "",  $words_in, $left_delim, "", "\t", $right_delim, $expected;
+	assemble_and_run "",  $words_in, $left_delim, "", "\n", $right_delim, $expected;
+	assemble_and_run "",  $words_in, $left_delim, "", "\f", $right_delim, $expected;
+
+	assemble_and_run "",  $words_in, $left_delim, " ", " ",   $right_delim, $expected;
+	assemble_and_run "",  $words_in, $left_delim, "\t", "\t", $right_delim, $expected;
+	assemble_and_run "",  $words_in, $left_delim, "\n", "\n", $right_delim, $expected;
+	assemble_and_run "",  $words_in, $left_delim, "\f", "\f", $right_delim, $expected;
+
+	assemble_and_run " ",  $words_in, $left_delim, " ", " ",   $right_delim, $expected;
+	assemble_and_run "\t", $words_in, $left_delim, "\t", "\t", $right_delim, $expected;
+	assemble_and_run "\n", $words_in, $left_delim, "\n", "\n", $right_delim, $expected;
+	assemble_and_run "\f", $words_in, $left_delim, "\f", "\f", $right_delim, $expected;
+
+	return;
 }

--- a/t/ppi_token_quotelike_words.t
+++ b/t/ppi_token_quotelike_words.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::QuoteLike::Words
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 1941;
+use Test::More tests => 1940 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 use Test::Deep;
 
 use PPI;

--- a/t/ppi_token_unknown.t
+++ b/t/ppi_token_unknown.t
@@ -1,0 +1,50 @@
+#!/usr/bin/perl
+
+# Unit testing for PPI::Token::Word
+
+use strict;
+use warnings;
+
+BEGIN {
+	$|  = 1;
+	$^W = 1;
+	no warnings 'once';
+	$PPI::XS_DISABLE = 1;
+	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
+}
+use Test::More tests => 2;
+use Test::NoWarnings;
+use PPI;
+
+OPERATOR_MULT_CAST: {
+	my @tests = (
+		{
+			desc     => 'multiply, not cast',
+			code     => '$c{d}*$e',
+			expected => [
+				'PPI::Statement'             => '$c{d}*$e',
+				'PPI::Token::Symbol'         => '$c',
+				'PPI::Structure::Subscript'  => '{d}',
+				'PPI::Token::Structure'      => '{',
+				'PPI::Statement::Expression' => 'd',
+				'PPI::Token::Word'           => 'd',
+				'PPI::Token::Structure'      => '}',
+				'PPI::Token::Operator'       => '*',
+				'PPI::Token::Symbol'         => '$e',
+			]
+		},
+	);
+
+	for my $test ( @tests ) {
+		my $d = PPI::Document->new( \$test->{code} );
+		my $tokens = $d->find( sub { 1 } );
+		$tokens = [ map { ref $_, $_->content } @$tokens ];
+		my $expected = $test->{expected};
+		unshift @$expected, 'PPI::Statement', $test->{code} if $expected->[0] !~ /^PPI::Statement/;
+		next if is_deeply( $tokens, $expected, $test->{desc} );
+
+		diag "$test->{code} ($test->{desc})\n";
+		diag explain $tokens;
+		diag explain $test->{expected};
+	}
+}

--- a/t/ppi_token_unknown.t
+++ b/t/ppi_token_unknown.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Unknown
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 2;
+use Test::More tests => 1 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/t/ppi_token_unknown.t
+++ b/t/ppi_token_unknown.t
@@ -1,20 +1,12 @@
 #!/usr/bin/perl
 
-# Unit testing for PPI::Token::Word
+# Unit testing for PPI::Token::Unknown
 
-use strict;
-use warnings;
-
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 2;
-use Test::NoWarnings;
+
 use PPI;
+
 
 OPERATOR_MULT_CAST: {
 	my @tests = (

--- a/t/ppi_token_word.t
+++ b/t/ppi_token_word.t
@@ -2,16 +2,9 @@
 
 # Unit testing for PPI::Token::Word
 
-use strict;
-BEGIN {
-	$|  = 1;
-	$^W = 1;
-	no warnings 'once';
-	$PPI::XS_DISABLE = 1;
-	$PPI::Lexer::X_TOKENIZER ||= $ENV{X_TOKENIZER};
-}
+use t::lib::PPI::Test::pragmas;
 use Test::More tests => 1756;
-use Test::NoWarnings;
+
 use PPI;
 
 

--- a/t/ppi_token_word.t
+++ b/t/ppi_token_word.t
@@ -3,7 +3,7 @@
 # Unit testing for PPI::Token::Word
 
 use t::lib::PPI::Test::pragmas;
-use Test::More tests => 1756;
+use Test::More tests => 1755 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 

--- a/xt/api.t
+++ b/xt/api.t
@@ -2,20 +2,16 @@
 
 # Basic first pass API testing for PPI
 
-use strict;
+use t::lib::PPI::Test::pragmas;
 use Test::More;
 BEGIN {
-	$| = 1;
-	$PPI::XS_DISABLE = 1;
-	$PPI::XS_DISABLE = 1; # Prevent warning
 	if ( $ENV{RELEASE_TESTING} ) {
 		plan( tests => 2931 );
 	} else {
-		plan( skip_all => 'Author tests not required for installation' );
+		plan( tests => 2931, skip_all => 'Author tests not required for installation' );
 	}
 }
-use File::Spec::Functions ':ALL';
-use Test::NoWarnings;
+
 use Test::ClassAPI;
 use PPI;
 use PPI::Dumper;

--- a/xt/api.t
+++ b/xt/api.t
@@ -5,10 +5,11 @@
 use t::lib::PPI::Test::pragmas;
 use Test::More;
 BEGIN {
+        my $tests = 2930 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 	if ( $ENV{RELEASE_TESTING} ) {
-		plan( tests => 2931 );
+		plan( tests => $tests );
 	} else {
-		plan( tests => 2931, skip_all => 'Author tests not required for installation' );
+		plan( tests => $tests, skip_all => 'Author tests not required for installation' );
 	}
 }
 


### PR DESCRIPTION
@dagolden's hitlist (https://gist.github.com/dagolden/69a93d45a34110498158) shows PPI as the second-highest consumer of Test-NoWarnings. Since warning tests for users have been considered to be harmful for a while (it prevents installation if perl core or something upstream introduces a new warning), these have been changed to run only for authors.
