### PR TITLE
Allow underscores in version strings.

### DIFF
--- a/lib/PPI/Token/Number/Version.pm
+++ b/lib/PPI/Token/Number/Version.pm
@@ -104,7 +104,7 @@ sub __TOKENIZER__commit {
 
 	# Get the rest of the line
 	pos $t->{line} = $t->{line_cursor};
-	if ( $t->{line} !~ m/\G(v\d+(?:\.\d+)*)/gc ) {
+	if ( $t->{line} !~ m/\G(v\d[\d_]*(?:\.\d[\d_]*)*)/gc ) {
 		# This was not a v-string after all (it's a word)
 		return PPI::Token::Word->__TOKENIZER__commit($t);
 	}


### PR DESCRIPTION
This should fix gh#66, rt#75038.  Although not exactly strict, it
doesn't appear to break anything.  Furthermore, versions like
`1_.23_45_' are actually perfectly valid in decimal version context.

Signed-off-by: Petr Šabata contyk@redhat.com
