### PR TITLE
do not rely on '.' being in @INC

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 
+use lib '.';
 use inc::Module::Install 1.10;
 
 all_from 'lib/PPI.pm';

--- a/t/01_compile.t
+++ b/t/01_compile.t
@@ -2,7 +2,8 @@
 
 # This test script only tests that the tree compiles
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 17 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 

--- a/t/03_document.t
+++ b/t/03_document.t
@@ -2,7 +2,8 @@
 
 # PPI::Document tests
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 13 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';

--- a/t/04_element.t
+++ b/t/04_element.t
@@ -5,13 +5,14 @@
 # This does an empiric test that when we try to parse something,
 # something ( anything ) comes out the other side.
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 220 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;
 use Scalar::Util 'refaddr';
-use t::lib::PPI::Test 'pause';
+use PPI::Test 'pause';
 
 
 sub is_object {

--- a/t/05_lexer.t
+++ b/t/05_lexer.t
@@ -3,14 +3,15 @@
 # Compare a large number of specific code samples (.code)
 # with the expected Lexer dumps (.dump).
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 218 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI::Lexer;
-use t::lib::PPI::Test::Run;
+use PPI::Test::Run;
 
 #####################################################################
 # Code/Dump Testing
 
-t::lib::PPI::Test::Run->run_testdir( catdir( 't', 'data', '05_lexer' ) );
+PPI::Test::Run->run_testdir( catdir( 't', 'data', '05_lexer' ) );

--- a/t/06_round_trip.t
+++ b/t/06_round_trip.t
@@ -3,12 +3,13 @@
 # Load ALL of the PPI files, lex them in, dump them
 # out, and verify that the code goes in and out cleanly.
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More; # Plan comes later
 
 use File::Spec::Functions ':ALL';
 use PPI;
-use t::lib::PPI::Test 'find_files';
+use PPI::Test 'find_files';
 
 
 

--- a/t/07_token.t
+++ b/t/07_token.t
@@ -2,12 +2,13 @@
 
 # Formal unit tests for specific PPI::Token classes
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 570 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;
-use t::lib::PPI::Test::Run;
+use PPI::Test::Run;
 
 
 
@@ -16,11 +17,11 @@ use t::lib::PPI::Test::Run;
 #####################################################################
 # Code/Dump Testing
 
-t::lib::PPI::Test::Run->run_testdir( catdir( 't', 'data', '07_token' ) );
+PPI::Test::Run->run_testdir( catdir( 't', 'data', '07_token' ) );
 
 {
 local $ENV{TODO} = "known bug";
-t::lib::PPI::Test::Run->run_testdir( catdir( 't', 'data', '07_token_todo' ) );
+PPI::Test::Run->run_testdir( catdir( 't', 'data', '07_token_todo' ) );
 }
 
 

--- a/t/08_regression.t
+++ b/t/08_regression.t
@@ -4,19 +4,20 @@
 
 # Some other regressions tests are included here for simplicity.
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 925 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
-use t::lib::PPI::Test 'pause';
-use t::lib::PPI::Test::Run;
+use PPI::Test 'pause';
+use PPI::Test::Run;
 
 
 
 #####################################################################
 # Code/Dump Testing
 
-t::lib::PPI::Test::Run->run_testdir(qw{ t data 08_regression });
+PPI::Test::Run->run_testdir(qw{ t data 08_regression });
 
 
 

--- a/t/09_normal.t
+++ b/t/09_normal.t
@@ -3,7 +3,8 @@
 # Testing of the normalization functions.
 # (only very basic at this point)
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 13 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';

--- a/t/10_statement.t
+++ b/t/10_statement.t
@@ -2,7 +2,8 @@
 
 # Test the various PPI::Statement packages
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 5 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/11_util.t
+++ b/t/11_util.t
@@ -2,7 +2,8 @@
 
 # Test the PPI::Util package
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 10 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';

--- a/t/12_location.t
+++ b/t/12_location.t
@@ -2,7 +2,8 @@
 
 # Tests the accuracy and features for location functionality
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 682 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/13_data.t
+++ b/t/13_data.t
@@ -2,7 +2,8 @@
 
 # Tests functionality relating to __DATA__ sections of files
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 7 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';

--- a/t/14_charsets.t
+++ b/t/14_charsets.t
@@ -1,6 +1,7 @@
 ﻿#!/usr/bin/perl
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More;
 BEGIN {
 	if ($] < 5.008007) {

--- a/t/15_transform.t
+++ b/t/15_transform.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More 0.86 tests => 23 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';

--- a/t/16_xml.t
+++ b/t/16_xml.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More 0.86 tests => 16 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/17_storable.t
+++ b/t/17_storable.t
@@ -2,7 +2,8 @@
 
 # Test compatibility with Storable
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More;
 BEGIN {
 	# Is Storable installed?

--- a/t/18_cache.t
+++ b/t/18_cache.t
@@ -2,7 +2,8 @@
 
 # Test PPI::Cache
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 42 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Unix;

--- a/t/19_selftesting.t
+++ b/t/19_selftesting.t
@@ -5,7 +5,8 @@
 
 # Using PPI to analyse its own code at install-time? Fuck yeah! :)
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More; # Plan comes later
 
 use Test::Object;
@@ -13,8 +14,8 @@ use File::Spec::Functions ':ALL';
 use Params::Util qw{_CLASS _ARRAY _INSTANCE _IDENTIFIER};
 use Class::Inspector;
 use PPI;
-use t::lib::PPI::Test 'find_files';
-use t::lib::PPI::Test::Object;
+use PPI::Test 'find_files';
+use PPI::Test::Object;
 
 use constant CI => 'Class::Inspector';
 

--- a/t/21_exhaustive.t
+++ b/t/21_exhaustive.t
@@ -2,12 +2,13 @@
 
 # Exhaustively test all possible Perl programs to a particular length
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More; # Plan comes later
 
 use Params::Util qw{_INSTANCE};
 use PPI;
-use t::lib::PPI::Test 'quotable';
+use PPI::Test 'quotable';
 
 use vars qw{$MAX_CHARS $ITERATIONS $LENGTH @ALL_CHARS @FAILURES};
 BEGIN {

--- a/t/22_readonly.t
+++ b/t/22_readonly.t
@@ -2,7 +2,8 @@
 
 # Testing of readonly functionality
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI::Document;

--- a/t/23_file.t
+++ b/t/23_file.t
@@ -2,7 +2,8 @@
 
 # Testing of PPI::Document::File
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 4 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';

--- a/t/24_v6.t
+++ b/t/24_v6.t
@@ -3,7 +3,8 @@
 # Regression test of a Perl 5 grammar that exploded
 # with a "98 subroutine recursion" error in 1.201
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';

--- a/t/25_increment.t
+++ b/t/25_increment.t
@@ -5,11 +5,12 @@
 # state between an empty document and the entire file to make sure
 # all of them parse as legal documents and don't crash the parser.
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 3875 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
-use t::lib::PPI::Test::Run;
+use PPI::Test::Run;
 
 
 
@@ -18,4 +19,4 @@ use t::lib::PPI::Test::Run;
 #####################################################################
 # Code/Dump Testing
 
-t::lib::PPI::Test::Run->increment_testdir(qw{ t data 08_regression });
+PPI::Test::Run->increment_testdir(qw{ t data 08_regression });

--- a/t/26_bom.t
+++ b/t/26_bom.t
@@ -1,9 +1,10 @@
 #!/usr/bin/perl
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 20 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
-use t::lib::PPI::Test::Run;
+use PPI::Test::Run;
 
 
 
@@ -12,4 +13,4 @@ use t::lib::PPI::Test::Run;
 #####################################################################
 # Code/Dump Testing
 
-t::lib::PPI::Test::Run->run_testdir(qw{ t data 26_bom });
+PPI::Test::Run->run_testdir(qw{ t data 26_bom });

--- a/t/27_complete.t
+++ b/t/27_complete.t
@@ -2,12 +2,13 @@
 
 # Testing for the PPI::Document ->complete method
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More; # Plan comes later
 
 use File::Spec::Functions ':ALL';
 use PPI;
-use t::lib::PPI::Test 'find_files';
+use PPI::Test 'find_files';
 
 # This test uses a series of ordered files, containing test code.
 # The letter after the number acts as a boolean yes/no answer to

--- a/t/28_foreach_qw.t
+++ b/t/28_foreach_qw.t
@@ -2,7 +2,8 @@
 
 # Standalone tests to check "foreach qw{foo} {}"
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 12 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 #use File::Spec::Functions ':ALL';

--- a/t/interactive.t
+++ b/t/interactive.t
@@ -4,7 +4,8 @@
 # Testing it here is much more efficient than having to trace
 # down through the entire set of regression tests.
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 2 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/lib/PPI/Test.pm
+++ b/t/lib/PPI/Test.pm
@@ -1,4 +1,4 @@
-package t::lib::PPI::Test;
+package PPI::Test;
 
 use warnings;
 use strict;

--- a/t/lib/PPI/Test/Object.pm
+++ b/t/lib/PPI/Test/Object.pm
@@ -1,4 +1,4 @@
-package t::lib::PPI::Test::Object;
+package PPI::Test::Object;
 
 use warnings;
 use strict;

--- a/t/lib/PPI/Test/Run.pm
+++ b/t/lib/PPI/Test/Run.pm
@@ -1,4 +1,4 @@
-package t::lib::PPI::Test::Run;
+package PPI::Test::Run;
 
 use File::Spec::Functions ':ALL';
 use Params::Util qw{_INSTANCE};
@@ -6,7 +6,8 @@ use PPI::Document;
 use PPI::Dumper;
 use Test::More;
 use Test::Object;
-use t::lib::PPI::Test::Object;
+use lib 't/lib';
+use PPI::Test::Object;
 
 use vars qw{$VERSION};
 BEGIN {

--- a/t/lib/PPI/Test/pragmas.pm
+++ b/t/lib/PPI/Test/pragmas.pm
@@ -1,4 +1,4 @@
-package t::lib::PPI::Test::pragmas;
+package PPI::Test::pragmas;
 
 =head1 NAME
 

--- a/t/ppi_element.t
+++ b/t/ppi_element.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Element
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 57 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_lexer.t
+++ b/t/ppi_lexer.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Lexer
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 43 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_node.t
+++ b/t/ppi_node.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Node
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 2 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_normal.t
+++ b/t/ppi_normal.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Normal
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 27 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_statement.t
+++ b/t/ppi_statement.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Statement
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 22 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_statement_compound.t
+++ b/t/ppi_statement_compound.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Statement::Compound
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 52 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_statement_include.t
+++ b/t/ppi_statement_include.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Statement::Include
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 2065 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Statement::Package
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 2506 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_statement_scheduled.t
+++ b/t/ppi_statement_scheduled.t
@@ -2,7 +2,8 @@
 
 # Test PPI::Statement::Scheduled
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 240 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_statement_sub.t
+++ b/t/ppi_statement_sub.t
@@ -2,7 +2,8 @@
 
 # Test PPI::Statement::Sub
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 1208 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_statement_variable.t
+++ b/t/ppi_statement_variable.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Statement::Variable
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 17 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token__quoteengine_full.t
+++ b/t/ppi_token__quoteengine_full.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::_QuoteEngine::Full
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 93 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_attribute.t
+++ b/t/ppi_token_attribute.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Attribute
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 1788 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_dashedword.t
+++ b/t/ppi_token_dashedword.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::DashedWord
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 9 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_heredoc.t
+++ b/t/ppi_token_heredoc.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::HereDoc
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 11 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_magic.t
+++ b/t/ppi_token_magic.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Magic
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 38 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_number_version.t
+++ b/t/ppi_token_number_version.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Number::Version
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 735 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Operator
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 1146 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_pod.t
+++ b/t/ppi_token_pod.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Pod
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_prototype.t
+++ b/t/ppi_token_prototype.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Prototype
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 800 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_quote.t
+++ b/t/ppi_token_quote.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Quote
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 15 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_quote_double.t
+++ b/t/ppi_token_quote_double.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Quote::Double
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 19 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_quote_interpolate.t
+++ b/t/ppi_token_quote_interpolate.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Quote::Interpolate
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 8 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_quote_literal.t
+++ b/t/ppi_token_quote_literal.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Quote::Literal
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 12 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_quote_single.t
+++ b/t/ppi_token_quote_single.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Quote::Single
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 24 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_quotelike_regexp.t
+++ b/t/ppi_token_quotelike_regexp.t
@@ -3,7 +3,8 @@
 use strict;
 use File::Spec::Functions ':ALL';
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use PPI;
 
 # Execute the tests

--- a/t/ppi_token_quotelike_words.t
+++ b/t/ppi_token_quotelike_words.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::QuoteLike::Words
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 1940 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 use Test::Deep;
 

--- a/t/ppi_token_regexp.t
+++ b/t/ppi_token_regexp.t
@@ -3,7 +3,8 @@
 use strict;
 use File::Spec::Functions ':ALL';
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use PPI;
 
 # Execute the tests

--- a/t/ppi_token_structure.t
+++ b/t/ppi_token_structure.t
@@ -3,7 +3,8 @@
 use strict;
 use File::Spec::Functions ':ALL';
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use PPI;
 
 # Execute the tests

--- a/t/ppi_token_symbol.t
+++ b/t/ppi_token_symbol.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Symbol
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 128 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_unknown.t
+++ b/t/ppi_token_unknown.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Unknown
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 132 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/t/ppi_token_word.t
+++ b/t/ppi_token_word.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Word
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 1762 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;

--- a/xt/api.t
+++ b/xt/api.t
@@ -2,7 +2,8 @@
 
 # Basic first pass API testing for PPI
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More;
 BEGIN {
         my $tests = 2931 + ($ENV{AUTHOR_TESTING} ? 1 : 0);


### PR DESCRIPTION
As of 5.25.7, Perl can be configured to not include '.' in `@INC` by default.
Update Makefile to use lib '.' so that it can find Module::Install on systems
that do not have it already (and use the local version in preference to
the system in versions that do).  Also rename the tests in 't/lib' and add
*just* that directory to `@INC`.