### PR TITLE
remove remaining usage of List::MoreUtils

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,7 +28,6 @@ eval {
 requires 'Clone'           => '0.30';
 requires 'File::Spec'      => win32() ? '3.2701' : '0.84';
 requires 'IO::String'      => '1.07';
-requires 'List::MoreUtils' => '0.16';
 requires 'List::Util'      => '1.33';
 requires 'Params::Util'    => '1.00';
 

--- a/lib/PPI/Element.pm
+++ b/lib/PPI/Element.pm
@@ -25,7 +25,7 @@ use strict;
 use Clone           ();
 use Scalar::Util    qw{refaddr};
 use Params::Util    qw{_INSTANCE _ARRAY};
-use List::MoreUtils ();
+use List::Util      ();
 use PPI::Util       ();
 use PPI::Node       ();
 
@@ -263,9 +263,9 @@ sub next_sibling {
 	my $parent   = $_PARENT{refaddr $self} or return '';
 	my $key      = refaddr $self;
 	my $elements = $parent->{children};
-	my $position = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-		} @$elements;
+	my $position = List::Util::first {
+		refaddr $elements->[$_] == $key
+		} 0..$#$elements;
 	$elements->[$position + 1] || '';
 }
 
@@ -286,9 +286,9 @@ sub snext_sibling {
 	my $parent   = $_PARENT{refaddr $self} or return '';
 	my $key      = refaddr $self;
 	my $elements = $parent->{children};
-	my $position = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-		} @$elements;
+	my $position = List::Util::first {
+		refaddr $elements->[$_] == $key
+		} 0..$#$elements;
 	while ( defined(my $it = $elements->[++$position]) ) {
 		return $it if $it->significant;
 	}
@@ -311,9 +311,9 @@ sub previous_sibling {
 	my $parent   = $_PARENT{refaddr $self} or return '';
 	my $key      = refaddr $self;
 	my $elements = $parent->{children};
-	my $position = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-		} @$elements;
+	my $position = List::Util::first {
+		refaddr $elements->[$_] == $key
+		} 0..$#$elements;
 	$position and $elements->[$position - 1] or '';
 }
 
@@ -334,9 +334,9 @@ sub sprevious_sibling {
 	my $parent   = $_PARENT{refaddr $self} or return '';
 	my $key      = refaddr $self;
 	my $elements = $parent->{children};
-	my $position = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-		} @$elements;
+	my $position = List::Util::first {
+		refaddr $elements->[$_] == $key
+		} 0..$#$elements;
 	while ( $position-- and defined(my $it = $elements->[$position]) ) {
 		return $it if $it->significant;
 	}

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -56,7 +56,6 @@ For more unusual tasks, by all means forge onwards.
 use strict;
 use Scalar::Util    ();
 use Params::Util    qw{_STRING _INSTANCE};
-use List::MoreUtils ();
 use PPI             ();
 use PPI::Exception  ();
 

--- a/lib/PPI/Node.pm
+++ b/lib/PPI/Node.pm
@@ -51,7 +51,7 @@ L<PPI::Element> objects also apply to C<PPI::Node> objects.
 use strict;
 use Carp            ();
 use Scalar::Util    qw{refaddr};
-use List::MoreUtils ();
+use List::Util      ();
 use Params::Util    qw{_INSTANCE _CLASS _CODELIKE _NUMBER};
 use PPI::Element    ();
 
@@ -512,10 +512,10 @@ sub remove_child {
 
 	# Find the position of the child
 	my $key = refaddr $child;
-	my $p   = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-	} @{$self->{children}};
-	return undef if $p == -1;
+	my $p   = List::Util::first {
+		refaddr $self->{children}[$_] == $key
+	} 0..$#{$self->{children}};
+	return undef unless defined $p;
 
 	# Splice it out, and remove the child's parent entry
 	splice( @{$self->{children}}, $p, 1 );
@@ -694,16 +694,16 @@ sub DESTROY {
 # Find the position of a child
 sub __position {
 	my $key = refaddr $_[1];
-	List::MoreUtils::firstidx { refaddr $_ == $key } @{$_[0]->{children}};
+	List::Util::first { refaddr $_[0]{children}[$_] == $key } 0..$#{$_[0]{children}};
 }
 
 # Insert one or more elements before a child
 sub __insert_before_child {
 	my $self = shift;
 	my $key  = refaddr shift;
-	my $p    = List::MoreUtils::firstidx {
-	         refaddr $_ == $key
-	         } @{$self->{children}};
+	my $p    = List::Util::first {
+	         refaddr $self->{children}[$_] == $key
+	         } 0..$#{$self->{children}};
 	foreach ( @_ ) {
 		Scalar::Util::weaken(
 			$_PARENT{refaddr $_} = $self
@@ -717,9 +717,9 @@ sub __insert_before_child {
 sub __insert_after_child {
 	my $self = shift;
 	my $key  = refaddr shift;
-	my $p    = List::MoreUtils::firstidx {
-	         refaddr $_ == $key
-	         } @{$self->{children}};
+	my $p    = List::Util::first {
+	         refaddr $self->{children}[$_] == $key
+	         } 0..$#{$self->{children}};
 	foreach ( @_ ) {
 		Scalar::Util::weaken(
 			$_PARENT{refaddr $_} = $self
@@ -733,9 +733,9 @@ sub __insert_after_child {
 sub __replace_child {
 	my $self = shift;
 	my $key  = refaddr shift;
-	my $p    = List::MoreUtils::firstidx {
-	         refaddr $_ == $key
-	         } @{$self->{children}};
+	my $p    = List::Util::first {
+	         refaddr $self->{children}[$_] == $key
+	         } 0..$#{$self->{children}};
 	foreach ( @_ ) {
 		Scalar::Util::weaken(
 			$_PARENT{refaddr $_} = $self

--- a/t/lib/PPI/Test/Object.pm
+++ b/t/lib/PPI/Test/Object.pm
@@ -3,7 +3,7 @@ package PPI::Test::Object;
 use warnings;
 use strict;
 
-use List::MoreUtils 'any';
+use List::Util 1.33 'any';
 use Params::Util qw{_INSTANCE};
 use PPI::Dumper;
 use Test::More;


### PR DESCRIPTION
The remaining usage of List::MoreUtils can be easily replaced with any and first from List::Util. The main difference between first and firstidx is that firstidx returns -1 if the element is not found, and first returns undef, but for the majority of these instances, this case is not currently checked for anyway -- it is assumed the document is consistent with itself so the node will be found.