### PR TITLE
Support postfix dereference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,13 @@
 /MYMETA.yml
 /MYMETA.json
 /Makefile
+/Makefile.old
 /README
 /blib
 /inc
 /pm_to_blib
 /MANIFEST
+/MANIFEST.bak
 /nytprof*
 /cover_db
+/PPI-*.tar.gz

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension PPI
 
+1.224 Sun 14 May 2017
+	Summary:
+	- updating an out-of-date meta.yml caused by Module::Install
+
 1.222 Sun 14 May 2017
 	Summary:
 	- unit tests for many parts, both passing and TODO

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl extension PPI
 
-1.222
+1.222 Sun 14 May 2017
 	Summary:
 	- unit tests for many parts, both passing and TODO
 	- many documentation fixes

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -9,4 +9,5 @@ Makefile$
 Makefile.old
 PPI-.*\.tar\.gz
 blib
+dev_notes.txt
 pm_to_blib

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,12 @@
+.git
+.gitignore
+.travis.yml
+MANIFEST.SKIP
+MANIFEST.bak
+MYMETA.json
+MYMETA.yml
+Makefile$
+Makefile.old
+PPI-.*\.tar\.gz
+blib
+pm_to_blib

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,7 +40,6 @@ requires 'Storable'    => '2.17';
 test_requires 'Class::Inspector' => '1.22';
 test_requires 'File::Remove'     => '1.42';
 test_requires 'Test::More'       => '0.86';
-test_requires 'Test::Warn'       => '0.30';
 test_requires 'Test::Object'     => '0.07';
 test_requires 'Test::SubCalls'   => '1.07';
 test_requires 'Test::Deep';

--- a/dev_notes.txt
+++ b/dev_notes.txt
@@ -1,0 +1,36 @@
+prove -l -v t | grep '^^[ \t]*ok.*TODO'
+prove -l -v t | grep '^^not ok'
+
+prove -vl t\ppi_token_unknown.t | grep '^^[ \t]*ok.*TODO'
+
+prove -vl t\ppi_token_unknown.t | grep '^^not ok'
+
+
+prove -l -j 9 t
+
+https://github.com/wolfsage/p5-distribution-smoke
+
+D:\cpan\p5-distribution-smoke>perl -Ilib bin\p5-distribution-smoke -b new -a Perl::Critic ../PPI
+
+D:\cpan\p5-distribution-smoke>perl -Ilib bin\p5-distribution-smoke -b new -r ../PPI
+
+
+perl -Ilib bin/p5-distribution-smoke -r -b new -n PPI -s MooseX::amine -s ^Task:: -s Apache2::PPI::HTML ../PPI
+
+perl -Ilib bin/p5-distribution-smoke -r -b old -n PPI -s MooseX::amine -s ^Task:: -s Apache2::PPI::HTML ../PPI
+
+
+perl -Ilib bin/p5-distribution-smoke -r -a Perl::Critic::* -b new -n PPI -s MooseX::amine -s ^Task:: -s Apache2::PPI::HTML ../PPI
+
+perl -Ilib bin/p5-distribution-smoke -r -a Perl::Critic::* -b old -n PPI -s MooseX::amine -s ^Task:: -s Apache2::PPI::HTML ../PPI
+
+
+perl -Ilib bin/p5-distribution-smoke -r -d 2 -b new -n PPI -s MooseX::amine -s ^Task:: -s Apache2::PPI::HTML ../PPI
+
+perl -Ilib bin/p5-distribution-smoke -r -d 2 -b old -n PPI -s MooseX::amine -s ^Task:: -s Apache2::PPI::HTML ../PPI
+
+
+ppi_version change 1.221_02 1.222
+
+dmake clean
+perl Makefile.PL && dmake && dmake manifest && dmake dist

--- a/lib/PPI.pm
+++ b/lib/PPI.pm
@@ -8,7 +8,7 @@ use strict;
 # Set the version for CPAN
 use vars qw{$VERSION $XS_COMPATIBLE @XS_EXCLUDE};
 BEGIN {
-	$VERSION       = '1.222';
+	$VERSION       = '1.224';
 	$XS_COMPATIBLE = '0.845';
 	@XS_EXCLUDE    = ();
 }

--- a/lib/PPI.pm
+++ b/lib/PPI.pm
@@ -8,7 +8,7 @@ use strict;
 # Set the version for CPAN
 use vars qw{$VERSION $XS_COMPATIBLE @XS_EXCLUDE};
 BEGIN {
-	$VERSION       = '1.221_02';
+	$VERSION       = '1.222';
 	$XS_COMPATIBLE = '0.845';
 	@XS_EXCLUDE    = ();
 }

--- a/lib/PPI/Cache.pm
+++ b/lib/PPI/Cache.pm
@@ -56,7 +56,7 @@ use PPI::Document ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 use constant VMS => !! ( $^O eq 'VMS' );

--- a/lib/PPI/Cache.pm
+++ b/lib/PPI/Cache.pm
@@ -56,7 +56,7 @@ use PPI::Document ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 use constant VMS => !! ( $^O eq 'VMS' );

--- a/lib/PPI/Document.pm
+++ b/lib/PPI/Document.pm
@@ -77,7 +77,7 @@ use overload '""'   => 'content';
 
 use vars qw{$VERSION @ISA $errstr};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Node';
 	$errstr  = '';
 }

--- a/lib/PPI/Document.pm
+++ b/lib/PPI/Document.pm
@@ -77,7 +77,7 @@ use overload '""'   => 'content';
 
 use vars qw{$VERSION @ISA $errstr};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Node';
 	$errstr  = '';
 }

--- a/lib/PPI/Document/File.pm
+++ b/lib/PPI/Document/File.pm
@@ -24,7 +24,7 @@ use PPI::Document ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Document';
 }
 

--- a/lib/PPI/Document/File.pm
+++ b/lib/PPI/Document/File.pm
@@ -24,7 +24,7 @@ use PPI::Document ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Document';
 }
 

--- a/lib/PPI/Document/Fragment.pm
+++ b/lib/PPI/Document/Fragment.pm
@@ -23,7 +23,7 @@ use PPI::Document ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Document';
 }
 

--- a/lib/PPI/Document/Fragment.pm
+++ b/lib/PPI/Document/Fragment.pm
@@ -23,7 +23,7 @@ use PPI::Document ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Document';
 }
 

--- a/lib/PPI/Document/Normalized.pm
+++ b/lib/PPI/Document/Normalized.pm
@@ -47,7 +47,7 @@ use PPI::Util    ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 use overload 'bool' => \&PPI::Util::TRUE;

--- a/lib/PPI/Document/Normalized.pm
+++ b/lib/PPI/Document/Normalized.pm
@@ -47,7 +47,7 @@ use PPI::Util    ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 use overload 'bool' => \&PPI::Util::TRUE;

--- a/lib/PPI/Dumper.pm
+++ b/lib/PPI/Dumper.pm
@@ -37,7 +37,7 @@ use Params::Util qw{_INSTANCE};
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/lib/PPI/Dumper.pm
+++ b/lib/PPI/Dumper.pm
@@ -37,7 +37,7 @@ use Params::Util qw{_INSTANCE};
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/lib/PPI/Element.pm
+++ b/lib/PPI/Element.pm
@@ -31,7 +31,7 @@ use PPI::Node       ();
 
 use vars qw{$VERSION $errstr %_PARENT};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	$errstr  = '';
 
 	# Master Child -> Parent index

--- a/lib/PPI/Element.pm
+++ b/lib/PPI/Element.pm
@@ -31,7 +31,7 @@ use PPI::Node       ();
 
 use vars qw{$VERSION $errstr %_PARENT};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	$errstr  = '';
 
 	# Master Child -> Parent index

--- a/lib/PPI/Exception.pm
+++ b/lib/PPI/Exception.pm
@@ -26,7 +26,7 @@ use Params::Util qw{_INSTANCE};
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/lib/PPI/Exception.pm
+++ b/lib/PPI/Exception.pm
@@ -26,7 +26,7 @@ use Params::Util qw{_INSTANCE};
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/lib/PPI/Exception/ParserRejection.pm
+++ b/lib/PPI/Exception/ParserRejection.pm
@@ -5,7 +5,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Exception';
 }
 

--- a/lib/PPI/Exception/ParserRejection.pm
+++ b/lib/PPI/Exception/ParserRejection.pm
@@ -5,7 +5,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Exception';
 }
 

--- a/lib/PPI/Find.pm
+++ b/lib/PPI/Find.pm
@@ -76,7 +76,7 @@ use Params::Util qw{_INSTANCE};
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/lib/PPI/Find.pm
+++ b/lib/PPI/Find.pm
@@ -76,7 +76,7 @@ use Params::Util qw{_INSTANCE};
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -1058,6 +1058,13 @@ sub _square {
 			# $foo[], @foo[]
 			return 'PPI::Structure::Subscript';
 		}
+		if ( $Element->isa('PPI::Token::Cast') and $Element->content =~ /^(?:\@|\%)/ ) {
+			my $prior = $Parent->schild(-2);
+			if ( $prior and $prior->isa('PPI::Token::Operator') and $prior->content eq '->' ) {
+				# Postfix dereference: ->@[...] ->%[...]
+				return 'PPI::Structure::Subscript';
+			}
+		}
 		# FIXME - More cases to catch
 	}
 
@@ -1136,6 +1143,13 @@ sub _curly {
 		if ( $content =~ /^(?:\$|\@)/ and $Element->isa('PPI::Token::Symbol') ) {
 			# $foo{}, @foo{}
 			return 'PPI::Structure::Subscript';
+		}
+		if ( $Element->isa('PPI::Token::Cast') and $Element->content =~ /^(?:\@|\%|\*)/ ) {
+			my $prior = $Parent->schild(-2);
+			if ( $prior and $prior->isa('PPI::Token::Operator') and $prior->content eq '->' ) {
+				# Postfix dereference: ->@{...} ->%{...} ->*{...}
+				return 'PPI::Structure::Subscript';
+			}
 		}
 		if ( $Element->isa('PPI::Structure::Block') ) {
 			# deference - ${$hash_ref}{foo}

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -62,7 +62,7 @@ use PPI::Exception  ();
 
 use vars qw{$VERSION $errstr *_PARENT %ROUND %RESOLVE};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	$errstr  = '';
 
 	# Faster than having another method call just

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -62,7 +62,7 @@ use PPI::Exception  ();
 
 use vars qw{$VERSION $errstr *_PARENT %ROUND %RESOLVE};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	$errstr  = '';
 
 	# Faster than having another method call just

--- a/lib/PPI/Node.pm
+++ b/lib/PPI/Node.pm
@@ -57,7 +57,7 @@ use PPI::Element    ();
 
 use vars qw{$VERSION @ISA *_PARENT};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Element';
 	*_PARENT = *PPI::Element::_PARENT;
 }

--- a/lib/PPI/Node.pm
+++ b/lib/PPI/Node.pm
@@ -57,7 +57,7 @@ use PPI::Element    ();
 
 use vars qw{$VERSION @ISA *_PARENT};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Element';
 	*_PARENT = *PPI::Element::_PARENT;
 }

--- a/lib/PPI/Normal.pm
+++ b/lib/PPI/Normal.pm
@@ -42,7 +42,7 @@ use PPI::Document::Normalized ();
 
 use vars qw{$VERSION %LAYER};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 
 	# Registered function store
 	%LAYER = (

--- a/lib/PPI/Normal.pm
+++ b/lib/PPI/Normal.pm
@@ -42,7 +42,7 @@ use PPI::Document::Normalized ();
 
 use vars qw{$VERSION %LAYER};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 
 	# Registered function store
 	%LAYER = (

--- a/lib/PPI/Normal/Standard.pm
+++ b/lib/PPI/Normal/Standard.pm
@@ -20,7 +20,7 @@ use strict;
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/lib/PPI/Normal/Standard.pm
+++ b/lib/PPI/Normal/Standard.pm
@@ -20,7 +20,7 @@ use strict;
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/lib/PPI/Statement.pm
+++ b/lib/PPI/Statement.pm
@@ -154,7 +154,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA *_PARENT};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Node';
 	*_PARENT = *PPI::Element::_PARENT;
 }

--- a/lib/PPI/Statement.pm
+++ b/lib/PPI/Statement.pm
@@ -154,7 +154,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA *_PARENT};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Node';
 	*_PARENT = *PPI::Element::_PARENT;
 }

--- a/lib/PPI/Statement/Break.pm
+++ b/lib/PPI/Statement/Break.pm
@@ -42,7 +42,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Break.pm
+++ b/lib/PPI/Statement/Break.pm
@@ -42,7 +42,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Compound.pm
+++ b/lib/PPI/Statement/Compound.pm
@@ -55,7 +55,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA %TYPES};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 
 	# Keyword type map

--- a/lib/PPI/Statement/Compound.pm
+++ b/lib/PPI/Statement/Compound.pm
@@ -55,7 +55,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA %TYPES};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 
 	# Keyword type map

--- a/lib/PPI/Statement/Data.pm
+++ b/lib/PPI/Statement/Data.pm
@@ -45,7 +45,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Data.pm
+++ b/lib/PPI/Statement/Data.pm
@@ -45,7 +45,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/End.pm
+++ b/lib/PPI/Statement/End.pm
@@ -49,7 +49,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/End.pm
+++ b/lib/PPI/Statement/End.pm
@@ -49,7 +49,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Expression.pm
+++ b/lib/PPI/Statement/Expression.pm
@@ -40,7 +40,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Expression.pm
+++ b/lib/PPI/Statement/Expression.pm
@@ -40,7 +40,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Given.pm
+++ b/lib/PPI/Statement/Given.pm
@@ -36,7 +36,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Given.pm
+++ b/lib/PPI/Statement/Given.pm
@@ -36,7 +36,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Include.pm
+++ b/lib/PPI/Statement/Include.pm
@@ -50,7 +50,7 @@ use PPI::Statement::Include::Perl6 ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Include.pm
+++ b/lib/PPI/Statement/Include.pm
@@ -50,7 +50,7 @@ use PPI::Statement::Include::Perl6 ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Include/Perl6.pm
+++ b/lib/PPI/Statement/Include/Perl6.pm
@@ -43,7 +43,7 @@ use PPI::Statement::Include ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement::Include';
 }
 

--- a/lib/PPI/Statement/Include/Perl6.pm
+++ b/lib/PPI/Statement/Include/Perl6.pm
@@ -43,7 +43,7 @@ use PPI::Statement::Include ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement::Include';
 }
 

--- a/lib/PPI/Statement/Null.pm
+++ b/lib/PPI/Statement/Null.pm
@@ -45,7 +45,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Null.pm
+++ b/lib/PPI/Statement/Null.pm
@@ -45,7 +45,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Package.pm
+++ b/lib/PPI/Statement/Package.pm
@@ -43,7 +43,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Package.pm
+++ b/lib/PPI/Statement/Package.pm
@@ -43,7 +43,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Scheduled.pm
+++ b/lib/PPI/Statement/Scheduled.pm
@@ -58,7 +58,7 @@ use PPI::Statement::Sub ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement::Sub';
 }
 

--- a/lib/PPI/Statement/Scheduled.pm
+++ b/lib/PPI/Statement/Scheduled.pm
@@ -58,7 +58,7 @@ use PPI::Statement::Sub ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement::Sub';
 }
 

--- a/lib/PPI/Statement/Sub.pm
+++ b/lib/PPI/Statement/Sub.pm
@@ -37,7 +37,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Sub.pm
+++ b/lib/PPI/Statement/Sub.pm
@@ -37,7 +37,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Unknown.pm
+++ b/lib/PPI/Statement/Unknown.pm
@@ -37,7 +37,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Unknown.pm
+++ b/lib/PPI/Statement/Unknown.pm
@@ -37,7 +37,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/UnmatchedBrace.pm
+++ b/lib/PPI/Statement/UnmatchedBrace.pm
@@ -49,7 +49,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/UnmatchedBrace.pm
+++ b/lib/PPI/Statement/UnmatchedBrace.pm
@@ -49,7 +49,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/Variable.pm
+++ b/lib/PPI/Statement/Variable.pm
@@ -44,7 +44,7 @@ use PPI::Statement::Expression ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement::Expression';
 }
 

--- a/lib/PPI/Statement/Variable.pm
+++ b/lib/PPI/Statement/Variable.pm
@@ -44,7 +44,7 @@ use PPI::Statement::Expression ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement::Expression';
 }
 

--- a/lib/PPI/Statement/When.pm
+++ b/lib/PPI/Statement/When.pm
@@ -44,7 +44,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Statement/When.pm
+++ b/lib/PPI/Statement/When.pm
@@ -44,7 +44,7 @@ use PPI::Statement ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Statement';
 }
 

--- a/lib/PPI/Structure.pm
+++ b/lib/PPI/Structure.pm
@@ -96,7 +96,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA *_PARENT};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Node';
 	*_PARENT = *PPI::Element::_PARENT;
 }

--- a/lib/PPI/Structure.pm
+++ b/lib/PPI/Structure.pm
@@ -96,7 +96,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA *_PARENT};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Node';
 	*_PARENT = *PPI::Element::_PARENT;
 }

--- a/lib/PPI/Structure/Block.pm
+++ b/lib/PPI/Structure/Block.pm
@@ -45,7 +45,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Block.pm
+++ b/lib/PPI/Structure/Block.pm
@@ -45,7 +45,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Condition.pm
+++ b/lib/PPI/Structure/Condition.pm
@@ -40,7 +40,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Condition.pm
+++ b/lib/PPI/Structure/Condition.pm
@@ -40,7 +40,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Constructor.pm
+++ b/lib/PPI/Structure/Constructor.pm
@@ -35,7 +35,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Constructor.pm
+++ b/lib/PPI/Structure/Constructor.pm
@@ -35,7 +35,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/For.pm
+++ b/lib/PPI/Structure/For.pm
@@ -36,7 +36,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/For.pm
+++ b/lib/PPI/Structure/For.pm
@@ -36,7 +36,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Given.pm
+++ b/lib/PPI/Structure/Given.pm
@@ -36,7 +36,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Given.pm
+++ b/lib/PPI/Structure/Given.pm
@@ -36,7 +36,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/List.pm
+++ b/lib/PPI/Structure/List.pm
@@ -39,7 +39,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/List.pm
+++ b/lib/PPI/Structure/List.pm
@@ -39,7 +39,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Subscript.pm
+++ b/lib/PPI/Structure/Subscript.pm
@@ -41,7 +41,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Subscript.pm
+++ b/lib/PPI/Structure/Subscript.pm
@@ -41,7 +41,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Unknown.pm
+++ b/lib/PPI/Structure/Unknown.pm
@@ -42,7 +42,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/Unknown.pm
+++ b/lib/PPI/Structure/Unknown.pm
@@ -42,7 +42,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/When.pm
+++ b/lib/PPI/Structure/When.pm
@@ -36,7 +36,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Structure/When.pm
+++ b/lib/PPI/Structure/When.pm
@@ -36,7 +36,7 @@ use PPI::Structure ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Structure';
 }
 

--- a/lib/PPI/Token.pm
+++ b/lib/PPI/Token.pm
@@ -27,7 +27,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Element';
 }
 

--- a/lib/PPI/Token.pm
+++ b/lib/PPI/Token.pm
@@ -27,7 +27,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Element';
 }
 

--- a/lib/PPI/Token/ArrayIndex.pm
+++ b/lib/PPI/Token/ArrayIndex.pm
@@ -29,7 +29,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/ArrayIndex.pm
+++ b/lib/PPI/Token/ArrayIndex.pm
@@ -29,7 +29,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Attribute.pm
+++ b/lib/PPI/Token/Attribute.pm
@@ -35,7 +35,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Attribute.pm
+++ b/lib/PPI/Token/Attribute.pm
@@ -35,7 +35,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/BOM.pm
+++ b/lib/PPI/Token/BOM.pm
@@ -44,7 +44,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/BOM.pm
+++ b/lib/PPI/Token/BOM.pm
@@ -44,7 +44,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Cast.pm
+++ b/lib/PPI/Token/Cast.pm
@@ -34,7 +34,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Cast.pm
+++ b/lib/PPI/Token/Cast.pm
@@ -34,7 +34,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Comment.pm
+++ b/lib/PPI/Token/Comment.pm
@@ -63,7 +63,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Comment.pm
+++ b/lib/PPI/Token/Comment.pm
@@ -63,7 +63,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/DashedWord.pm
+++ b/lib/PPI/Token/DashedWord.pm
@@ -31,7 +31,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/DashedWord.pm
+++ b/lib/PPI/Token/DashedWord.pm
@@ -31,7 +31,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Data.pm
+++ b/lib/PPI/Token/Data.pm
@@ -33,7 +33,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Data.pm
+++ b/lib/PPI/Token/Data.pm
@@ -33,7 +33,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/End.pm
+++ b/lib/PPI/Token/End.pm
@@ -45,7 +45,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/End.pm
+++ b/lib/PPI/Token/End.pm
@@ -45,7 +45,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/HereDoc.pm
+++ b/lib/PPI/Token/HereDoc.pm
@@ -89,7 +89,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/HereDoc.pm
+++ b/lib/PPI/Token/HereDoc.pm
@@ -89,7 +89,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Label.pm
+++ b/lib/PPI/Token/Label.pm
@@ -31,7 +31,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Label.pm
+++ b/lib/PPI/Token/Label.pm
@@ -31,7 +31,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Magic.pm
+++ b/lib/PPI/Token/Magic.pm
@@ -47,7 +47,7 @@ use PPI::Token::Unknown ();
 
 use vars qw{$VERSION @ISA %magic};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::Symbol';
 
 	# Magic variables taken from perlvar.

--- a/lib/PPI/Token/Magic.pm
+++ b/lib/PPI/Token/Magic.pm
@@ -47,7 +47,7 @@ use PPI::Token::Unknown ();
 
 use vars qw{$VERSION @ISA %magic};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::Symbol';
 
 	# Magic variables taken from perlvar.

--- a/lib/PPI/Token/Number.pm
+++ b/lib/PPI/Token/Number.pm
@@ -34,7 +34,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Number.pm
+++ b/lib/PPI/Token/Number.pm
@@ -34,7 +34,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Number/Binary.pm
+++ b/lib/PPI/Token/Number/Binary.pm
@@ -31,7 +31,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Number/Binary.pm
+++ b/lib/PPI/Token/Number/Binary.pm
@@ -31,7 +31,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Number/Exp.pm
+++ b/lib/PPI/Token/Number/Exp.pm
@@ -33,7 +33,7 @@ use PPI::Token::Number::Float ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::Number::Float';
 }
 

--- a/lib/PPI/Token/Number/Exp.pm
+++ b/lib/PPI/Token/Number/Exp.pm
@@ -33,7 +33,7 @@ use PPI::Token::Number::Float ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::Number::Float';
 }
 

--- a/lib/PPI/Token/Number/Float.pm
+++ b/lib/PPI/Token/Number/Float.pm
@@ -33,7 +33,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Number/Float.pm
+++ b/lib/PPI/Token/Number/Float.pm
@@ -33,7 +33,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Number/Hex.pm
+++ b/lib/PPI/Token/Number/Hex.pm
@@ -31,7 +31,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Number/Hex.pm
+++ b/lib/PPI/Token/Number/Hex.pm
@@ -31,7 +31,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Number/Octal.pm
+++ b/lib/PPI/Token/Number/Octal.pm
@@ -31,7 +31,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Number/Octal.pm
+++ b/lib/PPI/Token/Number/Octal.pm
@@ -31,7 +31,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Number/Version.pm
+++ b/lib/PPI/Token/Number/Version.pm
@@ -35,7 +35,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Number/Version.pm
+++ b/lib/PPI/Token/Number/Version.pm
@@ -35,7 +35,7 @@ use PPI::Token::Number ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::Number';
 }
 

--- a/lib/PPI/Token/Operator.pm
+++ b/lib/PPI/Token/Operator.pm
@@ -44,7 +44,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA %OPERATOR};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 
 	# Build the operator index

--- a/lib/PPI/Token/Operator.pm
+++ b/lib/PPI/Token/Operator.pm
@@ -44,7 +44,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA %OPERATOR};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 
 	# Build the operator index

--- a/lib/PPI/Token/Pod.pm
+++ b/lib/PPI/Token/Pod.pm
@@ -30,7 +30,7 @@ use PPI::Token   ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Pod.pm
+++ b/lib/PPI/Token/Pod.pm
@@ -30,7 +30,7 @@ use PPI::Token   ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Prototype.pm
+++ b/lib/PPI/Token/Prototype.pm
@@ -51,7 +51,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Prototype.pm
+++ b/lib/PPI/Token/Prototype.pm
@@ -51,7 +51,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Quote.pm
+++ b/lib/PPI/Token/Quote.pm
@@ -50,7 +50,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Quote.pm
+++ b/lib/PPI/Token/Quote.pm
@@ -50,7 +50,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Quote/Double.pm
+++ b/lib/PPI/Token/Quote/Double.pm
@@ -36,7 +36,7 @@ use PPI::Token::_QuoteEngine::Simple ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Simple
 		PPI::Token::Quote

--- a/lib/PPI/Token/Quote/Double.pm
+++ b/lib/PPI/Token/Quote/Double.pm
@@ -36,7 +36,7 @@ use PPI::Token::_QuoteEngine::Simple ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Simple
 		PPI::Token::Quote

--- a/lib/PPI/Token/Quote/Interpolate.pm
+++ b/lib/PPI/Token/Quote/Interpolate.pm
@@ -32,7 +32,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Quote

--- a/lib/PPI/Token/Quote/Interpolate.pm
+++ b/lib/PPI/Token/Quote/Interpolate.pm
@@ -32,7 +32,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Quote

--- a/lib/PPI/Token/Quote/Literal.pm
+++ b/lib/PPI/Token/Quote/Literal.pm
@@ -32,7 +32,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Quote

--- a/lib/PPI/Token/Quote/Literal.pm
+++ b/lib/PPI/Token/Quote/Literal.pm
@@ -32,7 +32,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Quote

--- a/lib/PPI/Token/Quote/Single.pm
+++ b/lib/PPI/Token/Quote/Single.pm
@@ -38,7 +38,7 @@ use PPI::Token::_QuoteEngine::Simple ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Simple
 		PPI::Token::Quote

--- a/lib/PPI/Token/Quote/Single.pm
+++ b/lib/PPI/Token/Quote/Single.pm
@@ -38,7 +38,7 @@ use PPI::Token::_QuoteEngine::Simple ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Simple
 		PPI::Token::Quote

--- a/lib/PPI/Token/QuoteLike.pm
+++ b/lib/PPI/Token/QuoteLike.pm
@@ -50,7 +50,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/QuoteLike.pm
+++ b/lib/PPI/Token/QuoteLike.pm
@@ -50,7 +50,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/QuoteLike/Backtick.pm
+++ b/lib/PPI/Token/QuoteLike/Backtick.pm
@@ -32,7 +32,7 @@ use PPI::Token::_QuoteEngine::Simple ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Simple
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/QuoteLike/Backtick.pm
+++ b/lib/PPI/Token/QuoteLike/Backtick.pm
@@ -32,7 +32,7 @@ use PPI::Token::_QuoteEngine::Simple ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Simple
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/QuoteLike/Command.pm
+++ b/lib/PPI/Token/QuoteLike/Command.pm
@@ -32,7 +32,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/QuoteLike/Command.pm
+++ b/lib/PPI/Token/QuoteLike/Command.pm
@@ -32,7 +32,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/QuoteLike/Readline.pm
+++ b/lib/PPI/Token/QuoteLike/Readline.pm
@@ -41,7 +41,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/QuoteLike/Readline.pm
+++ b/lib/PPI/Token/QuoteLike/Readline.pm
@@ -41,7 +41,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/QuoteLike/Regexp.pm
+++ b/lib/PPI/Token/QuoteLike/Regexp.pm
@@ -35,7 +35,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/QuoteLike/Regexp.pm
+++ b/lib/PPI/Token/QuoteLike/Regexp.pm
@@ -35,7 +35,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/QuoteLike/Words.pm
+++ b/lib/PPI/Token/QuoteLike/Words.pm
@@ -31,7 +31,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/QuoteLike/Words.pm
+++ b/lib/PPI/Token/QuoteLike/Words.pm
@@ -31,7 +31,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::QuoteLike

--- a/lib/PPI/Token/Regexp.pm
+++ b/lib/PPI/Token/Regexp.pm
@@ -47,7 +47,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Regexp.pm
+++ b/lib/PPI/Token/Regexp.pm
@@ -47,7 +47,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Regexp/Match.pm
+++ b/lib/PPI/Token/Regexp/Match.pm
@@ -46,7 +46,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Regexp

--- a/lib/PPI/Token/Regexp/Match.pm
+++ b/lib/PPI/Token/Regexp/Match.pm
@@ -46,7 +46,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Regexp

--- a/lib/PPI/Token/Regexp/Substitute.pm
+++ b/lib/PPI/Token/Regexp/Substitute.pm
@@ -36,7 +36,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Regexp

--- a/lib/PPI/Token/Regexp/Substitute.pm
+++ b/lib/PPI/Token/Regexp/Substitute.pm
@@ -36,7 +36,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Regexp

--- a/lib/PPI/Token/Regexp/Transliterate.pm
+++ b/lib/PPI/Token/Regexp/Transliterate.pm
@@ -40,7 +40,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Regexp

--- a/lib/PPI/Token/Regexp/Transliterate.pm
+++ b/lib/PPI/Token/Regexp/Transliterate.pm
@@ -40,7 +40,7 @@ use PPI::Token::_QuoteEngine::Full ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = qw{
 		PPI::Token::_QuoteEngine::Full
 		PPI::Token::Regexp

--- a/lib/PPI/Token/Separator.pm
+++ b/lib/PPI/Token/Separator.pm
@@ -37,7 +37,7 @@ use PPI::Token::Word ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::Word';
 }
 

--- a/lib/PPI/Token/Separator.pm
+++ b/lib/PPI/Token/Separator.pm
@@ -37,7 +37,7 @@ use PPI::Token::Word ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::Word';
 }
 

--- a/lib/PPI/Token/Structure.pm
+++ b/lib/PPI/Token/Structure.pm
@@ -33,7 +33,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Structure.pm
+++ b/lib/PPI/Token/Structure.pm
@@ -33,7 +33,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Symbol.pm
+++ b/lib/PPI/Token/Symbol.pm
@@ -33,7 +33,7 @@ use PPI::Token   ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Symbol.pm
+++ b/lib/PPI/Token/Symbol.pm
@@ -33,7 +33,7 @@ use PPI::Token   ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Unknown.pm
+++ b/lib/PPI/Token/Unknown.pm
@@ -33,7 +33,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA $CURLY_SYMBOL};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 	$CURLY_SYMBOL = qr{\G\^[[:upper:]_]\w+\}};
 }

--- a/lib/PPI/Token/Unknown.pm
+++ b/lib/PPI/Token/Unknown.pm
@@ -33,7 +33,7 @@ use PPI::Exception ();
 
 use vars qw{$VERSION @ISA $CURLY_SYMBOL};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 	$CURLY_SYMBOL = qr{\G\^[[:upper:]_]\w+\}};
 }

--- a/lib/PPI/Token/Whitespace.pm
+++ b/lib/PPI/Token/Whitespace.pm
@@ -47,7 +47,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Whitespace.pm
+++ b/lib/PPI/Token/Whitespace.pm
@@ -47,7 +47,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 }
 

--- a/lib/PPI/Token/Word.pm
+++ b/lib/PPI/Token/Word.pm
@@ -40,7 +40,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA %OPERATOR %QUOTELIKE %KEYWORDS};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token';
 
 	# Copy in OPERATOR from PPI::Token::Operator

--- a/lib/PPI/Token/Word.pm
+++ b/lib/PPI/Token/Word.pm
@@ -40,7 +40,7 @@ use PPI::Token ();
 
 use vars qw{$VERSION @ISA %OPERATOR %QUOTELIKE %KEYWORDS};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token';
 
 	# Copy in OPERATOR from PPI::Token::Operator

--- a/lib/PPI/Token/_QuoteEngine.pm
+++ b/lib/PPI/Token/_QuoteEngine.pm
@@ -35,7 +35,7 @@ use Carp ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/lib/PPI/Token/_QuoteEngine.pm
+++ b/lib/PPI/Token/_QuoteEngine.pm
@@ -35,7 +35,7 @@ use Carp ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/lib/PPI/Token/_QuoteEngine/Full.pm
+++ b/lib/PPI/Token/_QuoteEngine/Full.pm
@@ -9,7 +9,7 @@ use PPI::Token::_QuoteEngine ();
 
 use vars qw{$VERSION @ISA %quotes %sections};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::_QuoteEngine';
 
 	# Prototypes for the different braced sections

--- a/lib/PPI/Token/_QuoteEngine/Full.pm
+++ b/lib/PPI/Token/_QuoteEngine/Full.pm
@@ -9,7 +9,7 @@ use PPI::Token::_QuoteEngine ();
 
 use vars qw{$VERSION @ISA %quotes %sections};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::_QuoteEngine';
 
 	# Prototypes for the different braced sections

--- a/lib/PPI/Token/_QuoteEngine/Simple.pm
+++ b/lib/PPI/Token/_QuoteEngine/Simple.pm
@@ -7,7 +7,7 @@ use PPI::Token::_QuoteEngine ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA     = 'PPI::Token::_QuoteEngine';
 }
 

--- a/lib/PPI/Token/_QuoteEngine/Simple.pm
+++ b/lib/PPI/Token/_QuoteEngine/Simple.pm
@@ -7,7 +7,7 @@ use PPI::Token::_QuoteEngine ();
 
 use vars qw{$VERSION @ISA};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA     = 'PPI::Token::_QuoteEngine';
 }
 

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -89,7 +89,7 @@ use PPI::Exception::ParserRejection ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 # The x operator cannot follow most Perl operators, implying that

--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -89,7 +89,7 @@ use PPI::Exception::ParserRejection ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 # The x operator cannot follow most Perl operators, implying that

--- a/lib/PPI/Transform.pm
+++ b/lib/PPI/Transform.pm
@@ -23,7 +23,7 @@ use Params::Util  qw{_INSTANCE _CLASS _CODE _SCALAR0};
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/lib/PPI/Transform.pm
+++ b/lib/PPI/Transform.pm
@@ -23,7 +23,7 @@ use Params::Util  qw{_INSTANCE _CLASS _CODE _SCALAR0};
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/lib/PPI/Transform/UpdateCopyright.pm
+++ b/lib/PPI/Transform/UpdateCopyright.pm
@@ -33,7 +33,7 @@ use PPI::Transform ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/lib/PPI/Transform/UpdateCopyright.pm
+++ b/lib/PPI/Transform/UpdateCopyright.pm
@@ -33,7 +33,7 @@ use PPI::Transform ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/lib/PPI/Util.pm
+++ b/lib/PPI/Util.pm
@@ -9,7 +9,7 @@ use Params::Util qw{_INSTANCE _SCALAR0 _ARRAY0};
 
 use vars qw{$VERSION @ISA @EXPORT_OK};
 BEGIN {
-	$VERSION   = '1.221_02';
+	$VERSION   = '1.222';
 	@ISA       = 'Exporter';
 	@EXPORT_OK = qw{_Document _slurp};
 }

--- a/lib/PPI/Util.pm
+++ b/lib/PPI/Util.pm
@@ -9,7 +9,7 @@ use Params::Util qw{_INSTANCE _SCALAR0 _ARRAY0};
 
 use vars qw{$VERSION @ISA @EXPORT_OK};
 BEGIN {
-	$VERSION   = '1.222';
+	$VERSION   = '1.224';
 	@ISA       = 'Exporter';
 	@EXPORT_OK = qw{_Document _slurp};
 }

--- a/lib/PPI/XSAccessor.pm
+++ b/lib/PPI/XSAccessor.pm
@@ -9,7 +9,7 @@ use PPI ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/lib/PPI/XSAccessor.pm
+++ b/lib/PPI/XSAccessor.pm
@@ -9,7 +9,7 @@ use PPI ();
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/t/lib/Helper.pm
+++ b/t/lib/Helper.pm
@@ -4,7 +4,7 @@ use base 'Exporter';
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 @EXPORT_OK = qw( check_with );

--- a/t/lib/Helper.pm
+++ b/t/lib/Helper.pm
@@ -4,7 +4,7 @@ use base 'Exporter';
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 @EXPORT_OK = qw( check_with );

--- a/t/lib/PPI/Test.pm
+++ b/t/lib/PPI/Test.pm
@@ -7,7 +7,7 @@ use File::Spec::Functions ();
 
 use vars qw{$VERSION @ISA @EXPORT_OK %EXPORT_TAGS};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 	@ISA = 'Exporter';
 	@EXPORT_OK = qw( find_files quotable pause );
 }

--- a/t/lib/PPI/Test.pm
+++ b/t/lib/PPI/Test.pm
@@ -7,7 +7,7 @@ use File::Spec::Functions ();
 
 use vars qw{$VERSION @ISA @EXPORT_OK %EXPORT_TAGS};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 	@ISA = 'Exporter';
 	@EXPORT_OK = qw( find_files quotable pause );
 }

--- a/t/lib/PPI/Test/Object.pm
+++ b/t/lib/PPI/Test/Object.pm
@@ -11,7 +11,7 @@ use Test::Object;
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/t/lib/PPI/Test/Object.pm
+++ b/t/lib/PPI/Test/Object.pm
@@ -11,7 +11,7 @@ use Test::Object;
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/t/lib/PPI/Test/Run.pm
+++ b/t/lib/PPI/Test/Run.pm
@@ -11,7 +11,7 @@ use PPI::Test::Object;
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 

--- a/t/lib/PPI/Test/Run.pm
+++ b/t/lib/PPI/Test/Run.pm
@@ -11,7 +11,7 @@ use PPI::Test::Object;
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 

--- a/t/lib/PPI/Test/pragmas.pm
+++ b/t/lib/PPI/Test/pragmas.pm
@@ -22,7 +22,7 @@ use if $ENV{AUTHOR_TESTING}, 'Test::Warnings', ':no_end_test';
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.222';
+	$VERSION = '1.224';
 }
 
 BEGIN {

--- a/t/lib/PPI/Test/pragmas.pm
+++ b/t/lib/PPI/Test/pragmas.pm
@@ -22,7 +22,7 @@ use if $ENV{AUTHOR_TESTING}, 'Test::Warnings', ':no_end_test';
 
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.221_02';
+	$VERSION = '1.222';
 }
 
 BEGIN {

--- a/t/ppi_token_unknown.t
+++ b/t/ppi_token_unknown.t
@@ -4,7 +4,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 765 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 776 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 use B 'perlstring';
@@ -460,6 +460,143 @@ OPERATOR_CAST: {
 			'PPI::Token::Symbol' => '$i',
 			'PPI::Token::Operator' => '%',
 			'PPI::Token::Symbol' => '$f',
+		]
+	);
+
+	# Postfix dereference
+
+	test_statement(
+		'$foo->$*',
+		[
+			'PPI::Statement' => '$foo->$*',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '$*',
+		]
+	);
+
+	test_statement(
+		'$foo->@*',
+		[
+			'PPI::Statement' => '$foo->@*',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '@*',
+		]
+	);
+
+	test_statement(
+		'$foo->$#*',
+		[
+			'PPI::Statement' => '$foo->$#*',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '$#*',
+		]
+	);
+
+	test_statement(
+		'$foo->%*',
+		[
+			'PPI::Statement' => '$foo->%*',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '%*',
+		]
+	);
+
+	test_statement(
+		'$foo->&*',
+		[
+			'PPI::Statement' => '$foo->&*',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '&*',
+		]
+	);
+
+	test_statement(
+		'$foo->**',
+		[
+			'PPI::Statement' => '$foo->**',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '**',
+		]
+	);
+
+	test_statement(
+		'$foo->@[0]',
+		[
+			'PPI::Statement' => '$foo->@[0]',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '@',
+			'PPI::Structure::Subscript' => '[0]',
+			'PPI::Token::Structure' => '[',
+			'PPI::Statement::Expression' => '0',
+			'PPI::Token::Number' => '0',
+			'PPI::Token::Structure' => ']',
+		]
+	);
+
+	test_statement(
+		'$foo->@{0}',
+		[
+			'PPI::Statement' => '$foo->@{0}',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '@',
+			'PPI::Structure::Subscript' => '{0}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => '0',
+			'PPI::Token::Number' => '0',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+
+	test_statement(
+		'$foo->%["bar"]',
+		[
+			'PPI::Statement' => '$foo->%["bar"]',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '%',
+			'PPI::Structure::Subscript' => '["bar"]',
+			'PPI::Token::Structure' => '[',
+			'PPI::Statement::Expression' => '"bar"',
+			'PPI::Token::Quote::Double' => '"bar"',
+			'PPI::Token::Structure' => ']',
+		]
+	);
+
+	test_statement(
+		'$foo->%{bar}',
+		[
+			'PPI::Statement' => '$foo->%{bar}',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '%',
+			'PPI::Structure::Subscript' => '{bar}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'bar',
+			'PPI::Token::Word' => 'bar',
+			'PPI::Token::Structure' => '}',
+		]
+	);
+
+	test_statement(
+		'$foo->*{CODE}',
+		[
+			'PPI::Statement' => '$foo->*{CODE}',
+			'PPI::Token::Symbol' => '$foo',
+			'PPI::Token::Operator' => '->',
+			'PPI::Token::Cast' => '*',
+			'PPI::Structure::Subscript' => '{CODE}',
+			'PPI::Token::Structure' => '{',
+			'PPI::Statement::Expression' => 'CODE',
+			'PPI::Token::Word' => 'CODE',
+			'PPI::Token::Structure' => '}',
 		]
 	);
 


### PR DESCRIPTION
This resolves #88 

### `$foo->@*`

before:
```
PPI::Document
  PPI::Statement
    PPI::Token::Symbol          '$foo'
    PPI::Token::Operator        '->'
    PPI::Token::Magic   '@*'
```

after:
```
PPI::Document
  PPI::Statement
    PPI::Token::Symbol          '$foo'
    PPI::Token::Operator        '->'
    PPI::Token::Cast    '@*'
```

### `$foo->**`

before:
```
PPI::Document
  PPI::Statement
    PPI::Token::Symbol          '$foo'
    PPI::Token::Operator        '->'
    PPI::Token::Operator        '**'
```

after:
```
PPI::Document
  PPI::Statement
    PPI::Token::Symbol          '$foo'
    PPI::Token::Operator        '->'
    PPI::Token::Cast    '**'
```
### `$foo->%["bar"]`

before:
```
PPI::Document
  PPI::Statement
    PPI::Token::Symbol          '$foo'
    PPI::Token::Operator        '->'
    PPI::Token::Operator        '%'
    PPI::Structure::Constructor         [ ... ]
      PPI::Statement
        PPI::Token::Quote::Double       '"bar"'
```

after:
```
PPI::Document
  PPI::Statement
    PPI::Token::Symbol          '$foo'
    PPI::Token::Operator        '->'
    PPI::Token::Cast    '%'
    PPI::Structure::Subscript   [ ... ]
      PPI::Statement::Expression
        PPI::Token::Quote::Double       '"bar"'
```