### PR TITLE
Fix for Issue #206

### DIFF
--- a/lib/PPI/Tokenizer.pm
+++ b/lib/PPI/Tokenizer.pm
@@ -833,6 +833,7 @@ sub __current_token_is_forced_word {
 		# We also have to make sure that the sub/package/etc doing the forcing
 		# is not a method call.
 		if( $USUALLY_FORCES{$content}) {
+			return 1 if not defined $word;
 			return if $word =~ /^v[0-9]+$/ and ( $content eq "use" or $content eq "no" );
 			return 1 if not $prevprev;
 			return 1 if not $USUALLY_FORCES{$prevprev->content} and $prevprev->content ne '->';


### PR DESCRIPTION
Returns from function before using uninitialized $word variable in regex. Returns 1 like other failures seem to do, which is probably the correct way to do it in this case too. 