### PR TITLE
Support indented here-doc

### DIFF
--- a/lib/PPI/Token/HereDoc.pm
+++ b/lib/PPI/Token/HereDoc.pm
@@ -135,6 +135,25 @@ sub terminator {
 	shift->{_terminator};
 }
 
+sub _is_terminator {
+	my ( $self, $terminator, $line, $indented ) = @_;
+	if ( $indented ) {
+		return $line =~ /^\s*$terminator$/;
+	} else {
+		return $line eq $terminator;
+	}
+}
+
+sub _indent {
+	my ( $self, $token ) = @_;
+	my ($indent) = $token->{_terminator_line} =~ /^(\s*)/;
+	return $indent;
+}
+
+sub _is_match_indent {
+	my ( $self, $token, $indent ) = @_;
+	return (grep { /^$indent/ } @{$token->{_heredoc}}) == @{$token->{_heredoc}};
+}
 
 
 
@@ -144,7 +163,7 @@ sub terminator {
 
 # Parse in the entire here-doc in one call
 sub __TOKENIZER__on_char {
-	my $t     = $_[1];
+	my ( $self, $t ) = @_;
 
 	# We are currently located on the first char after the <<
 
@@ -153,7 +172,8 @@ sub __TOKENIZER__on_char {
 	### for the null here-doc, which terminates at the first
 	### empty line.
 	pos $t->{line} = $t->{line_cursor};
-	if ( $t->{line} !~ m/\G( \s* (?: "[^"]*" | '[^']*' | `[^`]*` | \\?\w+ ) )/gcx ) {
+
+	if ( $t->{line} !~ m/\G( ~? \s* (?: "[^"]*" | '[^']*' | `[^`]*` | \\?\w+ ) )/gcx ) {
 		# Degenerate to a left-shift operation
 		$t->{token}->set_class('Operator');
 		return $t->_finalize_token->__TOKENIZER__on_char( $t );
@@ -168,33 +188,38 @@ sub __TOKENIZER__on_char {
 	# Find the terminator, clean it up and determine
 	# the type of here-doc we are dealing with.
 	my $content = $token->{content};
-	if ( $content =~ /^\<\<(\w+)$/ ) {
+	if ( $content =~ /^\<\<(~?)(\w+)$/ ) {
 		# Bareword
 		$token->{_mode}       = 'interpolate';
-		$token->{_terminator} = $1;
+		$token->{_indented}   = 1 if $1 eq '~';
+		$token->{_terminator} = $2;
 
-	} elsif ( $content =~ /^\<\<\s*\'(.*)\'$/ ) {
+	} elsif ( $content =~ /^\<\<(~?)\s*\'(.*)\'$/ ) {
 		# ''-quoted literal
 		$token->{_mode}       = 'literal';
-		$token->{_terminator} = $1;
+		$token->{_indented}   = 1 if $1 eq '~';
+		$token->{_terminator} = $2;
 		$token->{_terminator} =~ s/\\'/'/g;
 
-	} elsif ( $content =~ /^\<\<\s*\"(.*)\"$/ ) {
+	} elsif ( $content =~ /^\<\<(~?)\s*\"(.*)\"$/ ) {
 		# ""-quoted literal
 		$token->{_mode}       = 'interpolate';
-		$token->{_terminator} = $1;
+		$token->{_indented}   = 1 if $1 eq '~';
+		$token->{_terminator} = $2;
 		$token->{_terminator} =~ s/\\"/"/g;
 
-	} elsif ( $content =~ /^\<\<\s*\`(.*)\`$/ ) {
+	} elsif ( $content =~ /^\<\<(~?)\s*\`(.*)\`$/ ) {
 		# ``-quoted command
 		$token->{_mode}       = 'command';
-		$token->{_terminator} = $1;
+		$token->{_indented}   = 1 if $1 eq '~';
+		$token->{_terminator} = $2;
 		$token->{_terminator} =~ s/\\`/`/g;
 
-	} elsif ( $content =~ /^\<\<\\(\w+)$/ ) {
+	} elsif ( $content =~ /^\<\<(~?)\\(\w+)$/ ) {
 		# Legacy forward-slashed bareword
 		$token->{_mode}       = 'literal';
-		$token->{_terminator} = $1;
+		$token->{_indented}   = 1 if $1 eq '~';
+		$token->{_terminator} = $2;
 
 	} else {
 		# WTF?
@@ -205,10 +230,21 @@ sub __TOKENIZER__on_char {
 	$token->{_heredoc} = \my @heredoc;
 	my $terminator = $token->{_terminator} . "\n";
 	while ( defined( my $line = $t->_get_line ) ) {
-		if ( $line eq $terminator ) {
+		if ( $self->_is_terminator( $terminator, $line, $token->{_indented} ) ) {
 			# Keep the actual termination line for consistency
 			# when we are re-assembling the file
 			$token->{_terminator_line} = $line;
+
+			if ( $token->{_indented} ) {
+				my $indent = $self->_indent( $token );
+				# Indentation of here-doc doesn't match delimiter
+				unless ( $self->_is_match_indent( $token, $indent ) ) {
+					push @heredoc, $line;
+					last;
+				}
+
+				s/^$indent// for @heredoc, $token->{_terminator_line};
+			}
 
 			# The HereDoc is now fully parsed
 			return $t->_finalize_token->__TOKENIZER__on_char( $t );
@@ -238,7 +274,17 @@ sub __TOKENIZER__on_char {
 		# newline at the end. If so, remove it from the content and set it as
 		# the terminator line.
 		$token->{_terminator_line} = pop @heredoc
-		  if $heredoc[-1] eq $token->{_terminator};
+			if $self->_is_terminator( $token->{_terminator}, $heredoc[-1], $token->{_indented} );
+	}
+
+	if ( $token->{_indented} && $token->{_terminator_line} ) {
+		my $indent = $self->_indent( $token );
+		if ( $self->_is_match_indent( $token, $indent ) ) {
+			# Remove indent from here-doc as much as possible
+			s/^$indent// for @heredoc;
+		}
+
+		s/^$indent// for $token->{_terminator_line};
 	}
 
 	# Set a hint for PPI::Document->serialize so it can

--- a/lib/PPI/Token/Operator.pm
+++ b/lib/PPI/Token/Operator.pm
@@ -93,10 +93,11 @@ sub __TOKENIZER__on_char {
 	# Handle the special case if we might be a here-doc
 	if ( $content eq '<<' ) {
 		pos $t->{line} = $t->{line_cursor};
-		# Either <<FOO or << 'FOO' or <<\FOO
+		# Either <<FOO  or << 'FOO'  or <<\FOO  or
+		#        <<~FOO or <<~ 'FOO' or <<~\FOO
 		### Is the zero-width look-ahead assertion really
 		### supposed to be there?
-		if ( $t->{line} =~ m/\G(?: (?!\d)\w | \s*['"`] | \\\w ) /gcx ) {
+		if ( $t->{line} =~ m/\G ~? (?: (?!\d)\w | \s*['"`] | \\\w ) /gcx ) {
 			# This is a here-doc.
 			# Change the class and move to the HereDoc's own __TOKENIZER__on_char method.
 			$t->{class} = $t->{token}->set_class('HereDoc');

--- a/t/ppi_token_heredoc.t
+++ b/t/ppi_token_heredoc.t
@@ -4,7 +4,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 11 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 29 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 use Test::Deep;
@@ -27,6 +27,7 @@ h	{
 			_damaged         => undef,
 			_terminator      => 'HERE',
 			_mode            => 'interpolate',
+			_indented        => undef,
 		},
 	};
 h	{
@@ -37,6 +38,18 @@ h	{
 			_damaged         => undef,
 			_terminator      => 'HERE',
 			_mode            => 'literal',
+			_indented        => undef,
+		},
+	};
+h	{
+		name     => 'Single-quoted bareword terminator with space.',
+		content  => "my \$heredoc = << 'HERE';\nLine 1\nLine 2\nHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+			_indented        => undef,
 		},
 	};
 h	{
@@ -47,6 +60,18 @@ h	{
 			_damaged         => undef,
 			_terminator      => 'HERE',
 			_mode            => 'interpolate',
+			_indented        => undef,
+		},
+	};
+h	{
+		name     => 'Double-quoted bareword terminator with space.',
+		content  => "my \$heredoc = << \"HERE\";\nLine 1\nLine 2\nHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+			_indented        => undef,
 		},
 	};
 h	{
@@ -57,6 +82,18 @@ h	{
 			_damaged         => undef,
 			_terminator      => 'HERE',
 			_mode            => 'command',
+			_indented        => undef,
+		},
+	};
+h	{
+		name     => 'Command-quoted terminator with space.',
+		content  => "my \$heredoc = << `HERE`;\nLine 1\nLine 2\nHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'command',
+			_indented        => undef,
 		},
 	};
 h	{
@@ -67,6 +104,7 @@ h	{
 			_damaged         => undef,
 			_terminator      => 'HERE',
 			_mode            => 'literal',
+			_indented        => undef,
 		},
 	};
 
@@ -79,6 +117,7 @@ h	{
 			_damaged         => 1,
 			_terminator      => 'HERE',
 			_mode            => 'interpolate',
+			_indented        => undef,
 		},
 	};
 h	{
@@ -89,6 +128,7 @@ h	{
 			_damaged         => 1,
 			_terminator      => 'HERE',
 			_mode            => 'literal',
+			_indented        => undef,
 		},
 	};
 h	{
@@ -99,6 +139,7 @@ h	{
 			_damaged         => 1,
 			_terminator      => 'HERE',
 			_mode            => 'interpolate',
+			_indented        => undef,
 		},
 	};
 h	{
@@ -109,6 +150,7 @@ h	{
 			_damaged         => 1,
 			_terminator      => 'HERE',
 			_mode            => 'command',
+			_indented        => undef,
 		},
 	};
 h	{
@@ -119,6 +161,7 @@ h	{
 			_damaged         => 1,
 			_terminator      => 'HERE',
 			_mode            => 'literal',
+			_indented        => undef,
 		},
 	};
 
@@ -131,6 +174,180 @@ h	{
 			_damaged         => 1,
 			_terminator      => 'HERE',
 			_mode            => 'interpolate',
+			_indented        => undef,
+		},
+	};
+
+	# Tests indented here-document with a carriage return after the termination marker.
+h	{
+		name     => 'Bareword terminator (indented).',
+		content  => "my \$heredoc = <<~HERE;\n\t \tLine 1\n\t \tLine 2\n\t \tHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Single-quoted bareword terminator (indented).',
+		content  => "my \$heredoc = <<~'HERE';\n\t \tLine 1\n\t \tLine 2\n\t \tHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Single-quoted bareword terminator with space (indented).',
+		content  => "my \$heredoc = <<~ 'HERE';\n\t \tLine 1\n\t \tLine 2\n\t \tHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Double-quoted bareword terminator (indented).',
+		content  => "my \$heredoc = <<~\"HERE\";\n\t \tLine 1\n\t \tLine 2\n\t \tHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Double-quoted bareword terminator with space (indented).',
+		content  => "my \$heredoc = <<~ \"HERE\";\n\t \tLine 1\n\t \tLine 2\n\t \tHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Command-quoted terminator (indented).',
+		content  => "my \$heredoc = <<~`HERE`;\n\t \tLine 1\n\t \tLine 2\n\t \tHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'command',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Command-quoted terminator with space (indented).',
+		content  => "my \$heredoc = <<~ `HERE`;\n\t \tLine 1\n\t \tLine 2\n\t \tHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'command',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Legacy escaped bareword terminator (indented).',
+		content  => "my \$heredoc = <<~\\HERE;\n\t \tLine 1\n\t \tLine 2\n\t \tHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => undef,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+			_indented        => 1,
+		},
+	};
+
+	# Tests indented here-document without a carriage return after the termination marker.
+h	{
+		name     => 'Bareword terminator (indented and no return).',
+		content  => "my \$heredoc = <<~HERE;\n\t \tLine 1\n\t \tLine 2\n\t \tHERE",
+		expected => {
+			_terminator_line => 'HERE',
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Single-quoted bareword terminator (indented and no return).',
+		content  => "my \$heredoc = <<~'HERE';\n\t \tLine 1\n\t \tLine 2\n\t \tHERE",
+		expected => {
+			_terminator_line => "HERE",
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Double-quoted bareword terminator (indented and no return).',
+		content  => "my \$heredoc = <<~\"HERE\";\n\t \tLine 1\n\t \tLine 2\n\t \tHERE",
+		expected => {
+			_terminator_line => 'HERE',
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Command-quoted terminator (indented and no return).',
+		content  => "my \$heredoc = <<~`HERE`;\n\t \tLine 1\n\t \tLine 2\n\t \tHERE",
+		expected => {
+			_terminator_line => 'HERE',
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'command',
+			_indented        => 1,
+		},
+	};
+h	{
+		name     => 'Legacy escaped bareword terminator (indented and no return).',
+		content  => "my \$heredoc = <<~\\HERE;\n\t \tLine 1\n\t \tLine 2\n\t \tHERE",
+		expected => {
+			_terminator_line => 'HERE',
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'literal',
+			_indented        => 1,
+		},
+	};
+
+	# Tests indented here-document without a terminator.
+h	{
+		name     => 'Unterminated heredoc block (indented).',
+		content  => "my \$heredoc = <<~HERE;\nLine 1\nLine 2\n",
+		expected => {
+			_terminator_line => undef,
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+			_indented        => 1,
+		},
+	};
+
+	# Tests indented here-document where indentation doesn't match
+h	{
+		name     => 'Unterminated heredoc block (indented).',
+		content  => "my \$heredoc = <<~HERE;\nLine 1\nLine 2\n\t \tHERE\n",
+		expected => {
+			_terminator_line => "HERE\n",
+			_damaged         => 1,
+			_terminator      => 'HERE',
+			_mode            => 'interpolate',
+			_indented        => 1,
 		},
 	};
 


### PR DESCRIPTION
This p-r supports indented here-doc from perl-5.26 and resolves #203

```perl
my $heredoc = <<~HERE
    indented
    HERE
```

before:
```
PPI::Document
  PPI::Statement::Variable
    PPI::Token::Word    'my'
    PPI::Token::Whitespace      ' '
    PPI::Token::Symbol          '$heredoc'
    PPI::Token::Whitespace      ' '
    PPI::Token::Operator        '='
    PPI::Token::Whitespace      ' '
    PPI::Token::Operator        '<<'
    PPI::Token::Operator        '~'
    PPI::Token::Word    'HERE'
    PPI::Token::Whitespace      '\n'
    PPI::Token::Whitespace      '    '
    PPI::Token::Word    'indented'
    PPI::Token::Whitespace      '\n'
    PPI::Token::Whitespace      '    '
    PPI::Token::Word    'HERE'
  PPI::Token::Whitespace        '\n'
```

after:
```
PPI::Document
  PPI::Statement::Variable
    PPI::Token::Word    'my'
    PPI::Token::Whitespace      ' '
    PPI::Token::Symbol          '$heredoc'
    PPI::Token::Whitespace      ' '
    PPI::Token::Operator        '='
    PPI::Token::Whitespace      ' '
    PPI::Token::HereDoc         '<<~HERE'
  PPI::Token::Whitespace        '\n'
```

Also indented heredoc removes specified indentation from the result of calling `$heredoc->heredoc`.

```perl
my $content = q(
my $heredoc = <<~HERE
    indented
    HERE
);

my $doc = PPI::Document->new(\$content);
my $heredoc = $doc->find_first('PPI::Token::HereDoc');
print $heredoc->heredoc; # "indented\n"
```