### PR TITLE
Support lexical subroutine

### DIFF
--- a/lib/PPI/Statement/Sub.pm
+++ b/lib/PPI/Statement/Sub.pm
@@ -172,6 +172,32 @@ sub reserved {
 	$name eq uc $name;
 }
 
+=pod
+
+=head2 type
+
+The C<type> method checks and returns the declaration type of the statement,
+which will be one of 'my', 'our', or 'state'.
+
+Returns a string of the type, or C<undef> if the type is not declared.
+
+=cut
+
+sub type {
+	my $self = shift;
+
+	# Get the first significant child
+	my @schild = grep { $_->significant } $self->children;
+
+	# Ignore labels
+	shift @schild if _INSTANCE($schild[0], 'PPI::Token::Label');
+
+	# Get the type
+	(_INSTANCE($schild[0], 'PPI::Token::Word') and $schild[0]->content =~ /^(my|our|state)$/)
+		? $schild[0]->content
+		: undef;
+}
+
 1;
 
 =pod

--- a/lib/PPI/Token/Whitespace.pm
+++ b/lib/PPI/Token/Whitespace.pm
@@ -247,6 +247,12 @@ sub __TOKENIZER__on_char {
 					and
 					$p2->content eq ''
 				)
+				or (
+					# Lexical subroutine
+					$p2->isa('PPI::Token::Word')
+					and
+					$p2->content =~ /^(?:my|our|state)$/
+				)
 			)
 		) {
 			# This is a sub prototype

--- a/t/ppi_statement_sub.t
+++ b/t/ppi_statement_sub.t
@@ -4,7 +4,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 1208 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 1240 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 
@@ -40,6 +40,27 @@ NAME: {
 
 		};
 
+	}
+}
+
+LEXSUB: {
+	for my $test (
+		{ code => 'sub foo {}', type => undef },
+		{ code => 'my sub foo {}', type => 'my' },
+		{ code => 'our sub foo {}', type => 'our' },
+		{ code => 'state sub foo {}', type => 'state' },
+		{ code => 'my sub foo ($) {}', type => 'my' },
+	) {
+		my $code = $test->{code};
+		my $type = $test->{type};
+
+		my $Document = PPI::Document->new( \$code );
+		isa_ok( $Document, 'PPI::Document', "$code: got document" );
+
+		my ( $sub_statement, $dummy ) = $Document->schildren();
+		isa_ok( $sub_statement, 'PPI::Statement::Sub', "$code: document child is a sub" );
+		is( $dummy, undef, "$code: document has exactly one child" );
+		is( $sub_statement->type, $type, "$code: type matches" );
 	}
 }
 
@@ -88,6 +109,27 @@ PROTOTYPE: {
 		my ( $proto_text, $expected ) = @$test;
 
 		my $Document = PPI::Document->new( \"sub foo $proto_text {}" );
+		isa_ok( $Document, 'PPI::Document', "$proto_text got document" );
+
+		my ( $sub_statement, $dummy ) = $Document->schildren();
+		isa_ok( $sub_statement, 'PPI::Statement::Sub', "$proto_text document child is a sub" );
+		is( $dummy, undef, "$proto_text document has exactly one child" );
+		is( $sub_statement->prototype, $expected, "$proto_text: prototype matches" );
+	}
+}
+
+PROTOTYPE_LEXSUB: {
+	# Doesn't have to be as thorough as ppi_token_prototype.t, since
+	# we're just making sure PPI::Token::Prototype->prototype gets
+	# passed through correctly.
+	for my $test (
+		[ '',         undef ],
+		[ '()',       '' ],
+		[ '( $*Z@ )', '$*Z@' ],
+	) {
+		my ( $proto_text, $expected ) = @$test;
+
+		my $Document = PPI::Document->new( \"my sub foo $proto_text {}" );
 		isa_ok( $Document, 'PPI::Document', "$proto_text got document" );
 
 		my ( $sub_statement, $dummy ) = $Document->schildren();


### PR DESCRIPTION
Add support for lexical subroutine from perl-5.26

```perl
my sub foo ($) {}
```

before:
```
PPI::Document
  PPI::Statement::Variable
    PPI::Token::Word    'my'
    PPI::Token::Whitespace      ' '
    PPI::Token::Word    'sub'
    PPI::Token::Whitespace      ' '
    PPI::Token::Word    'foo'
    PPI::Token::Whitespace      ' '
    PPI::Structure::List        ( ... ???
      PPI::Statement::Expression
        PPI::Token::Magic       '$)'
        PPI::Token::Whitespace          ' '
        PPI::Structure::Subscript       { ... }
```

after:
```
PPI::Document
  PPI::Statement::Sub
    PPI::Token::Word    'my'
    PPI::Token::Whitespace      ' '
    PPI::Token::Word    'sub'
    PPI::Token::Whitespace      ' '
    PPI::Token::Word    'foo'
    PPI::Token::Whitespace      ' '
    PPI::Token::Prototype       '($)'
    PPI::Token::Whitespace      ' '
    PPI::Structure::Block       { ... }
```

Now `PPI::Statement::Sub` have `type` method which return declared type (`"my"`, `"our"`, `"state"` or `undef`).