### PR TITLE
t/marpa.t: Fix test reliance on '.' in @INC

### DIFF
--- a/t/marpa.t
+++ b/t/marpa.t
@@ -2,7 +2,8 @@
 
 # Unit testing for PPI::Token::Unknown
 
-use t::lib::PPI::Test::pragmas;
+use lib 't/lib';
+use PPI::Test::pragmas;
 use Test::More tests => 23 + ( $ENV{AUTHOR_TESTING} ? 1 : 0 );
 use B 'perlstring';
 


### PR DESCRIPTION
Fixes https://github.com/adamkennedy/PPI/issues/200

Tested with:

```bash
export PERL_USE_UNSAFE_INC=0
perl Makefile.PL
make test
```