### PR TITLE
Add test covering misparse bug for '(1)-1'

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,7 +28,6 @@ eval {
 requires 'Clone'           => '0.30';
 requires 'File::Spec'      => win32() ? '3.2701' : '0.84';
 requires 'IO::String'      => '1.07';
-requires 'List::MoreUtils' => '0.16';
 requires 'List::Util'      => '1.33';
 requires 'Params::Util'    => '1.00';
 

--- a/lib/PPI.pm
+++ b/lib/PPI.pm
@@ -8,11 +8,7 @@ use strict;
 # Set the version for CPAN
 our $VERSION = '1.236';
 
-use vars qw{$XS_COMPATIBLE @XS_EXCLUDE};
-BEGIN {
-	$XS_COMPATIBLE = '0.845';
-	@XS_EXCLUDE    = ();
-}
+our ( $XS_COMPATIBLE, @XS_EXCLUDE ) = ( '0.845' );
 
 # Load everything
 use PPI::Util                 ();

--- a/lib/PPI/Document.pm
+++ b/lib/PPI/Document.pm
@@ -77,11 +77,7 @@ use overload '""'   => 'content';
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA $errstr};
-BEGIN {
-	@ISA     = 'PPI::Node';
-	$errstr  = '';
-}
+our ( $errstr, @ISA ) = ( "", "PPI::Node" );
 
 use PPI::Document::Fragment ();
 

--- a/lib/PPI/Document/File.pm
+++ b/lib/PPI/Document/File.pm
@@ -24,10 +24,7 @@ use PPI::Document ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Document';
-}
+our @ISA = 'PPI::Document';
 
 
 

--- a/lib/PPI/Document/Fragment.pm
+++ b/lib/PPI/Document/Fragment.pm
@@ -23,10 +23,7 @@ use PPI::Document ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Document';
-}
+our @ISA = 'PPI::Document';
 
 
 

--- a/lib/PPI/Element.pm
+++ b/lib/PPI/Element.pm
@@ -31,13 +31,7 @@ use PPI::Node       ();
 
 our $VERSION = '1.236';
 
-use vars qw{$errstr %_PARENT};
-BEGIN {
-	$errstr  = '';
-
-	# Master Child -> Parent index
-	%_PARENT = ();
-}
+our ( $errstr, %_PARENT ) = ( "" );    # Master Child -> Parent index
 
 use overload 'bool' => \&PPI::Util::TRUE;
 use overload '""'   => 'content';

--- a/lib/PPI/Element.pm
+++ b/lib/PPI/Element.pm
@@ -28,10 +28,11 @@ use Params::Util    qw{_INSTANCE _ARRAY};
 use List::MoreUtils ();
 use PPI::Util       ();
 use PPI::Node       ();
+use PPI::Singletons '%_PARENT';
 
 our $VERSION = '1.236';
 
-our ( $errstr, %_PARENT ) = ( "" );    # Master Child -> Parent index
+our $errstr = "";
 
 use overload 'bool' => \&PPI::Util::TRUE;
 use overload '""'   => 'content';

--- a/lib/PPI/Element.pm
+++ b/lib/PPI/Element.pm
@@ -25,7 +25,7 @@ use strict;
 use Clone           ();
 use Scalar::Util    qw{refaddr};
 use Params::Util    qw{_INSTANCE _ARRAY};
-use List::MoreUtils ();
+use List::Util      ();
 use PPI::Util       ();
 use PPI::Node       ();
 use PPI::Singletons '%_PARENT';
@@ -259,9 +259,9 @@ sub next_sibling {
 	my $parent   = $_PARENT{refaddr $self} or return '';
 	my $key      = refaddr $self;
 	my $elements = $parent->{children};
-	my $position = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-		} @$elements;
+	my $position = List::Util::first {
+		refaddr $elements->[$_] == $key
+		} 0..$#$elements;
 	$elements->[$position + 1] || '';
 }
 
@@ -282,9 +282,9 @@ sub snext_sibling {
 	my $parent   = $_PARENT{refaddr $self} or return '';
 	my $key      = refaddr $self;
 	my $elements = $parent->{children};
-	my $position = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-		} @$elements;
+	my $position = List::Util::first {
+		refaddr $elements->[$_] == $key
+		} 0..$#$elements;
 	while ( defined(my $it = $elements->[++$position]) ) {
 		return $it if $it->significant;
 	}
@@ -307,9 +307,9 @@ sub previous_sibling {
 	my $parent   = $_PARENT{refaddr $self} or return '';
 	my $key      = refaddr $self;
 	my $elements = $parent->{children};
-	my $position = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-		} @$elements;
+	my $position = List::Util::first {
+		refaddr $elements->[$_] == $key
+		} 0..$#$elements;
 	$position and $elements->[$position - 1] or '';
 }
 
@@ -330,9 +330,9 @@ sub sprevious_sibling {
 	my $parent   = $_PARENT{refaddr $self} or return '';
 	my $key      = refaddr $self;
 	my $elements = $parent->{children};
-	my $position = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-		} @$elements;
+	my $position = List::Util::first {
+		refaddr $elements->[$_] == $key
+		} 0..$#$elements;
 	while ( $position-- and defined(my $it = $elements->[$position]) ) {
 		return $it if $it->significant;
 	}

--- a/lib/PPI/Exception/ParserRejection.pm
+++ b/lib/PPI/Exception/ParserRejection.pm
@@ -5,9 +5,6 @@ use PPI::Exception ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Exception';
-}
+our @ISA = 'PPI::Exception';
 
 1;

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -59,6 +59,7 @@ use Params::Util    qw{_STRING _INSTANCE};
 use List::MoreUtils ();
 use PPI             ();
 use PPI::Exception  ();
+use PPI::Singletons '%_PARENT';
 
 our $VERSION = '1.236';
 
@@ -84,13 +85,6 @@ our %RESOLVE = (
 	'[' => '_square',
 	'{' => '_curly',
 );
-
-our %_PARENT;
-BEGIN {
-	# Faster than having another method call just
-	# to set the structure finish token.
-	*_PARENT = *PPI::Element::_PARENT;
-}
 
 # Allows for experimental overriding of the tokenizer
 our $X_TOKENIZER = "PPI::Tokenizer";

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -62,43 +62,39 @@ use PPI::Exception  ();
 
 our $VERSION = '1.236';
 
-use vars qw{$errstr *_PARENT %ROUND %RESOLVE};
-BEGIN {
-	$errstr  = '';
+our $errstr = "";
 
+# Keyword -> Structure class maps
+our %ROUND = (
+	# Conditions
+	'if'     => 'PPI::Structure::Condition',
+	'elsif'  => 'PPI::Structure::Condition',
+	'unless' => 'PPI::Structure::Condition',
+	'while'  => 'PPI::Structure::Condition',
+	'until'  => 'PPI::Structure::Condition',
+
+	# For(each)
+	'for'     => 'PPI::Structure::For',
+	'foreach' => 'PPI::Structure::For',
+);
+
+# Opening brace to refining method
+our %RESOLVE = (
+	'(' => '_round',
+	'[' => '_square',
+	'{' => '_curly',
+);
+
+our %_PARENT;
+BEGIN {
 	# Faster than having another method call just
 	# to set the structure finish token.
 	*_PARENT = *PPI::Element::_PARENT;
-
-	# Keyword -> Structure class maps
-	%ROUND = (
-		# Conditions
-		'if'     => 'PPI::Structure::Condition',
-		'elsif'  => 'PPI::Structure::Condition',
-		'unless' => 'PPI::Structure::Condition',
-		'while'  => 'PPI::Structure::Condition',
-		'until'  => 'PPI::Structure::Condition',
-
-		# For(each)
-		'for'     => 'PPI::Structure::For',
-		'foreach' => 'PPI::Structure::For',
-	);
-
-	# Opening brace to refining method
-	%RESOLVE = (
-		'(' => '_round',
-		'[' => '_square',
-		'{' => '_curly',
-	);
-
 }
 
 # Allows for experimental overriding of the tokenizer
-use vars qw{ $X_TOKENIZER };
-BEGIN {
-	$X_TOKENIZER ||= 'PPI::Tokenizer';
-}
-use constant X_TOKENIZER => $X_TOKENIZER;
+our $X_TOKENIZER = "PPI::Tokenizer";
+sub X_TOKENIZER { $X_TOKENIZER }
 
 
 
@@ -340,62 +336,59 @@ sub _lex_document {
 #####################################################################
 # Lex Methods - Statement Object
 
-use vars qw{%STATEMENT_CLASSES};
-BEGIN {
-	# Keyword -> Statement Subclass
-	%STATEMENT_CLASSES = (
-		# Things that affect the timing of execution
-		'BEGIN'     => 'PPI::Statement::Scheduled',
-		'CHECK'     => 'PPI::Statement::Scheduled',
-		'UNITCHECK' => 'PPI::Statement::Scheduled',
-		'INIT'      => 'PPI::Statement::Scheduled',
-		'END'       => 'PPI::Statement::Scheduled',
+# Keyword -> Statement Subclass
+our %STATEMENT_CLASSES = (
+	# Things that affect the timing of execution
+	'BEGIN'     => 'PPI::Statement::Scheduled',
+	'CHECK'     => 'PPI::Statement::Scheduled',
+	'UNITCHECK' => 'PPI::Statement::Scheduled',
+	'INIT'      => 'PPI::Statement::Scheduled',
+	'END'       => 'PPI::Statement::Scheduled',
 
-		# Special subroutines for which 'sub' is optional
-		'AUTOLOAD'  => 'PPI::Statement::Sub',
-		'DESTROY'   => 'PPI::Statement::Sub',
+	# Special subroutines for which 'sub' is optional
+	'AUTOLOAD'  => 'PPI::Statement::Sub',
+	'DESTROY'   => 'PPI::Statement::Sub',
 
-		# Loading and context statement
-		'package'   => 'PPI::Statement::Package',
-		# 'use'       => 'PPI::Statement::Include',
-		'no'        => 'PPI::Statement::Include',
-		'require'   => 'PPI::Statement::Include',
+	# Loading and context statement
+	'package'   => 'PPI::Statement::Package',
+	# 'use'       => 'PPI::Statement::Include',
+	'no'        => 'PPI::Statement::Include',
+	'require'   => 'PPI::Statement::Include',
 
-		# Various declarations
-		'my'        => 'PPI::Statement::Variable',
-		'local'     => 'PPI::Statement::Variable',
-		'our'       => 'PPI::Statement::Variable',
-		'state'     => 'PPI::Statement::Variable',
-		# Statements starting with 'sub' could be any one of...
-		# 'sub'     => 'PPI::Statement::Sub',
-		# 'sub'     => 'PPI::Statement::Scheduled',
-		# 'sub'     => 'PPI::Statement',
+	# Various declarations
+	'my'        => 'PPI::Statement::Variable',
+	'local'     => 'PPI::Statement::Variable',
+	'our'       => 'PPI::Statement::Variable',
+	'state'     => 'PPI::Statement::Variable',
+	# Statements starting with 'sub' could be any one of...
+	# 'sub'     => 'PPI::Statement::Sub',
+	# 'sub'     => 'PPI::Statement::Scheduled',
+	# 'sub'     => 'PPI::Statement',
 
-		# Compound statement
-		'if'        => 'PPI::Statement::Compound',
-		'unless'    => 'PPI::Statement::Compound',
-		'for'       => 'PPI::Statement::Compound',
-		'foreach'   => 'PPI::Statement::Compound',
-		'while'     => 'PPI::Statement::Compound',
-		'until'     => 'PPI::Statement::Compound',
+	# Compound statement
+	'if'        => 'PPI::Statement::Compound',
+	'unless'    => 'PPI::Statement::Compound',
+	'for'       => 'PPI::Statement::Compound',
+	'foreach'   => 'PPI::Statement::Compound',
+	'while'     => 'PPI::Statement::Compound',
+	'until'     => 'PPI::Statement::Compound',
 
-		# Switch statement
-		'given'     => 'PPI::Statement::Given',
-		'when'      => 'PPI::Statement::When',
-		'default'   => 'PPI::Statement::When',
+	# Switch statement
+	'given'     => 'PPI::Statement::Given',
+	'when'      => 'PPI::Statement::When',
+	'default'   => 'PPI::Statement::When',
 
-		# Various ways of breaking out of scope
-		'redo'      => 'PPI::Statement::Break',
-		'next'      => 'PPI::Statement::Break',
-		'last'      => 'PPI::Statement::Break',
-		'return'    => 'PPI::Statement::Break',
-		'goto'      => 'PPI::Statement::Break',
+	# Various ways of breaking out of scope
+	'redo'      => 'PPI::Statement::Break',
+	'next'      => 'PPI::Statement::Break',
+	'last'      => 'PPI::Statement::Break',
+	'return'    => 'PPI::Statement::Break',
+	'goto'      => 'PPI::Statement::Break',
 
-		# Special sections of the file
-		'__DATA__'  => 'PPI::Statement::Data',
-		'__END__'   => 'PPI::Statement::End',
-	);
-}
+	# Special sections of the file
+	'__DATA__'  => 'PPI::Statement::Data',
+	'__END__'   => 'PPI::Statement::End',
+);
 
 sub _statement {
 	my ($self, $Parent, $Token) = @_;
@@ -1066,50 +1059,47 @@ sub _square {
 	'PPI::Structure::Constructor';
 }
 
-use vars qw{%CURLY_CLASSES @CURLY_LOOKAHEAD_CLASSES};
-BEGIN {
-	# Keyword -> Structure class maps
-	%CURLY_CLASSES = (
-		# Blocks
-		'sub'  => 'PPI::Structure::Block',
-		'grep' => 'PPI::Structure::Block',
-		'map'  => 'PPI::Structure::Block',
-		'sort' => 'PPI::Structure::Block',
-		'do'   => 'PPI::Structure::Block',
-		# rely on 'continue' + block being handled elsewhere
-		# rely on 'eval' + block being handled elsewhere
+# Keyword -> Structure class maps
+our %CURLY_CLASSES = (
+	# Blocks
+	'sub'  => 'PPI::Structure::Block',
+	'grep' => 'PPI::Structure::Block',
+	'map'  => 'PPI::Structure::Block',
+	'sort' => 'PPI::Structure::Block',
+	'do'   => 'PPI::Structure::Block',
+	# rely on 'continue' + block being handled elsewhere
+	# rely on 'eval' + block being handled elsewhere
 
-		# Hash constructors
-		'scalar' => 'PPI::Structure::Constructor',
-		'='      => 'PPI::Structure::Constructor',
-		'||='    => 'PPI::Structure::Constructor',
-		'&&='    => 'PPI::Structure::Constructor',
-		'//='    => 'PPI::Structure::Constructor',
-		'||'     => 'PPI::Structure::Constructor',
-		'&&'     => 'PPI::Structure::Constructor',
-		'//'     => 'PPI::Structure::Constructor',
-		'?'      => 'PPI::Structure::Constructor',
-		':'      => 'PPI::Structure::Constructor',
-		','      => 'PPI::Structure::Constructor',
-		'=>'     => 'PPI::Structure::Constructor',
-		'+'      => 'PPI::Structure::Constructor', # per perlref
-		'return' => 'PPI::Structure::Constructor', # per perlref
-		'bless'  => 'PPI::Structure::Constructor', # pragmatic --
-		            # perlfunc says first arg is a reference, and
-			    # bless {; ... } fails to compile.
-	);
+	# Hash constructors
+	'scalar' => 'PPI::Structure::Constructor',
+	'='      => 'PPI::Structure::Constructor',
+	'||='    => 'PPI::Structure::Constructor',
+	'&&='    => 'PPI::Structure::Constructor',
+	'//='    => 'PPI::Structure::Constructor',
+	'||'     => 'PPI::Structure::Constructor',
+	'&&'     => 'PPI::Structure::Constructor',
+	'//'     => 'PPI::Structure::Constructor',
+	'?'      => 'PPI::Structure::Constructor',
+	':'      => 'PPI::Structure::Constructor',
+	','      => 'PPI::Structure::Constructor',
+	'=>'     => 'PPI::Structure::Constructor',
+	'+'      => 'PPI::Structure::Constructor', # per perlref
+	'return' => 'PPI::Structure::Constructor', # per perlref
+	'bless'  => 'PPI::Structure::Constructor', # pragmatic --
+				# perlfunc says first arg is a reference, and
+			# bless {; ... } fails to compile.
+);
 
-	@CURLY_LOOKAHEAD_CLASSES = (
-	    {},	# not used
-	    {
-		';'    => 'PPI::Structure::Block', # per perlref
-		'}'    => 'PPI::Structure::Constructor',
-	    },
-	    {
-		'=>'   => 'PPI::Structure::Constructor',
-	    },
-	);
-}
+our @CURLY_LOOKAHEAD_CLASSES = (
+	{},	# not used
+	{
+	';'    => 'PPI::Structure::Block', # per perlref
+	'}'    => 'PPI::Structure::Constructor',
+	},
+	{
+	'=>'   => 'PPI::Structure::Constructor',
+	},
+);
 
 
 # Given a parent element, and a { token to open a structure, determine

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -56,7 +56,6 @@ For more unusual tasks, by all means forge onwards.
 use strict;
 use Scalar::Util    ();
 use Params::Util    qw{_STRING _INSTANCE};
-use List::MoreUtils ();
 use PPI             ();
 use PPI::Exception  ();
 use PPI::Singletons '%_PARENT';

--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -66,7 +66,7 @@ our $VERSION = '1.236';
 our $errstr = "";
 
 # Keyword -> Structure class maps
-our %ROUND = (
+my %ROUND = (
 	# Conditions
 	'if'     => 'PPI::Structure::Condition',
 	'elsif'  => 'PPI::Structure::Condition',
@@ -80,7 +80,7 @@ our %ROUND = (
 );
 
 # Opening brace to refining method
-our %RESOLVE = (
+my %RESOLVE = (
 	'(' => '_round',
 	'[' => '_square',
 	'{' => '_curly',
@@ -331,7 +331,7 @@ sub _lex_document {
 # Lex Methods - Statement Object
 
 # Keyword -> Statement Subclass
-our %STATEMENT_CLASSES = (
+my %STATEMENT_CLASSES = (
 	# Things that affect the timing of execution
 	'BEGIN'     => 'PPI::Statement::Scheduled',
 	'CHECK'     => 'PPI::Statement::Scheduled',
@@ -1054,7 +1054,7 @@ sub _square {
 }
 
 # Keyword -> Structure class maps
-our %CURLY_CLASSES = (
+my %CURLY_CLASSES = (
 	# Blocks
 	'sub'  => 'PPI::Structure::Block',
 	'grep' => 'PPI::Structure::Block',
@@ -1084,7 +1084,7 @@ our %CURLY_CLASSES = (
 			# bless {; ... } fails to compile.
 );
 
-our @CURLY_LOOKAHEAD_CLASSES = (
+my @CURLY_LOOKAHEAD_CLASSES = (
 	{},	# not used
 	{
 	';'    => 'PPI::Structure::Block', # per perlref

--- a/lib/PPI/Node.pm
+++ b/lib/PPI/Node.pm
@@ -54,17 +54,11 @@ use Scalar::Util    qw{refaddr};
 use List::MoreUtils ();
 use Params::Util    qw{_INSTANCE _CLASS _CODELIKE _NUMBER};
 use PPI::Element    ();
+use PPI::Singletons '%_PARENT';
 
 our $VERSION = '1.236';
 
 our @ISA = "PPI::Element";
-
-our %_PARENT;
-BEGIN {
-	# Faster than having another method call just
-	# to set the structure finish token.
-	*_PARENT = *PPI::Element::_PARENT;
-}
 
 
 

--- a/lib/PPI/Node.pm
+++ b/lib/PPI/Node.pm
@@ -51,7 +51,7 @@ L<PPI::Element> objects also apply to C<PPI::Node> objects.
 use strict;
 use Carp            ();
 use Scalar::Util    qw{refaddr};
-use List::MoreUtils ();
+use List::Util      ();
 use Params::Util    qw{_INSTANCE _CLASS _CODELIKE _NUMBER};
 use PPI::Element    ();
 use PPI::Singletons '%_PARENT';
@@ -510,10 +510,10 @@ sub remove_child {
 
 	# Find the position of the child
 	my $key = refaddr $child;
-	my $p   = List::MoreUtils::firstidx {
-		refaddr $_ == $key
-	} @{$self->{children}};
-	return undef if $p == -1;
+	my $p   = List::Util::first {
+		refaddr $self->{children}[$_] == $key
+	} 0..$#{$self->{children}};
+	return undef unless defined $p;
 
 	# Splice it out, and remove the child's parent entry
 	splice( @{$self->{children}}, $p, 1 );
@@ -692,16 +692,16 @@ sub DESTROY {
 # Find the position of a child
 sub __position {
 	my $key = refaddr $_[1];
-	List::MoreUtils::firstidx { refaddr $_ == $key } @{$_[0]->{children}};
+	List::Util::first { refaddr $_[0]{children}[$_] == $key } 0..$#{$_[0]{children}};
 }
 
 # Insert one or more elements before a child
 sub __insert_before_child {
 	my $self = shift;
 	my $key  = refaddr shift;
-	my $p    = List::MoreUtils::firstidx {
-	         refaddr $_ == $key
-	         } @{$self->{children}};
+	my $p    = List::Util::first {
+	         refaddr $self->{children}[$_] == $key
+	         } 0..$#{$self->{children}};
 	foreach ( @_ ) {
 		Scalar::Util::weaken(
 			$_PARENT{refaddr $_} = $self
@@ -715,9 +715,9 @@ sub __insert_before_child {
 sub __insert_after_child {
 	my $self = shift;
 	my $key  = refaddr shift;
-	my $p    = List::MoreUtils::firstidx {
-	         refaddr $_ == $key
-	         } @{$self->{children}};
+	my $p    = List::Util::first {
+	         refaddr $self->{children}[$_] == $key
+	         } 0..$#{$self->{children}};
 	foreach ( @_ ) {
 		Scalar::Util::weaken(
 			$_PARENT{refaddr $_} = $self
@@ -731,9 +731,9 @@ sub __insert_after_child {
 sub __replace_child {
 	my $self = shift;
 	my $key  = refaddr shift;
-	my $p    = List::MoreUtils::firstidx {
-	         refaddr $_ == $key
-	         } @{$self->{children}};
+	my $p    = List::Util::first {
+	         refaddr $self->{children}[$_] == $key
+	         } 0..$#{$self->{children}};
 	foreach ( @_ ) {
 		Scalar::Util::weaken(
 			$_PARENT{refaddr $_} = $self

--- a/lib/PPI/Node.pm
+++ b/lib/PPI/Node.pm
@@ -57,9 +57,12 @@ use PPI::Element    ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA *_PARENT};
+our @ISA = "PPI::Element";
+
+our %_PARENT;
 BEGIN {
-	@ISA     = 'PPI::Element';
+	# Faster than having another method call just
+	# to set the structure finish token.
 	*_PARENT = *PPI::Element::_PARENT;
 }
 

--- a/lib/PPI/Normal.pm
+++ b/lib/PPI/Normal.pm
@@ -40,10 +40,9 @@ use List::Util 1.33           ();
 use PPI::Util                 '_Document';
 use PPI::Document::Normalized ();
 use PPI::Normal::Standard     ();
+use PPI::Singletons           '%LAYER';
 
 our $VERSION = '1.236';
-
-our %LAYER = ( 1 => [], 2 => [] );    # Registered function store
 
 # With the registration mechanism in place, load in the main set of
 # normalization methods to initialize the store.

--- a/lib/PPI/Normal.pm
+++ b/lib/PPI/Normal.pm
@@ -39,19 +39,15 @@ use Carp                      ();
 use List::Util 1.33           ();
 use PPI::Util                 '_Document';
 use PPI::Document::Normalized ();
+use PPI::Normal::Standard     ();
 
 our $VERSION = '1.236';
 
-use vars qw{%LAYER};
-BEGIN {
+our %LAYER = ( 1 => [], 2 => [] );    # Registered function store
 
-	# Registered function store
-	%LAYER = (
-		1 => [],
-		2 => [],
-	);
-}
-
+# With the registration mechanism in place, load in the main set of
+# normalization methods to initialize the store.
+PPI::Normal::Standard->import;
 
 
 
@@ -102,10 +98,6 @@ sub register {
 
 	1;
 }
-
-# With the registration mechanism in place, load in the main set of
-# normalization methods to initialize the store.
-use PPI::Normal::Standard;
 
 
 

--- a/lib/PPI/Singletons.pm
+++ b/lib/PPI/Singletons.pm
@@ -1,0 +1,91 @@
+package PPI::Singletons;
+
+# exports some singleton variables to avoid aliasing magic
+
+use strict;
+use Exporter     ();
+
+our $VERSION = '1.236';
+
+our @ISA       = 'Exporter';
+our @EXPORT_OK = qw{ %_PARENT %OPERATOR %MAGIC %LAYER $CURLY_SYMBOL %QUOTELIKE %KEYWORDS };
+
+our %_PARENT; # Master Child -> Parent index
+
+# operator index
+our %OPERATOR = map { $_ => 1 } (
+	qw{
+	-> ++ -- ** ! ~ + -
+	=~ !~ * / % x . << >>
+	< > <= >= lt gt le ge
+	== != <=> eq ne cmp ~~
+	& | ^ && || // .. ...
+	? :
+	= **= += -= .= *= /= %= x= &= |= ^= <<= >>= &&= ||= //=
+	=> <>
+	and or xor not
+	}, ',' 	# Avoids "comma in qw{}" warning
+);
+
+# Magic variables taken from perlvar.
+# Several things added separately to avoid warnings.
+our %MAGIC = map { $_ => 1 } qw{
+	$1 $2 $3 $4 $5 $6 $7 $8 $9
+	$_ $& $` $' $+ @+ %+ $* $. $/ $|
+	$\\ $" $; $% $= $- @- %- $)
+	$~ $^ $: $? $! %! $@ $$ $< $>
+	$( $0 $[ $] @_ @*
+
+	$^L $^A $^E $^C $^D $^F $^H
+	$^I $^M $^N $^O $^P $^R $^S
+	$^T $^V $^W $^X %^H
+
+	$::|
+}, '$}', '$,', '$#', '$#+', '$#-';
+
+our %LAYER = ( 1 => [], 2 => [] );    # Registered function store
+
+our $CURLY_SYMBOL = qr{\G\^[[:upper:]_]\w+\}};
+
+our %QUOTELIKE = (
+	'q'  => 'Quote::Literal',
+	'qq' => 'Quote::Interpolate',
+	'qx' => 'QuoteLike::Command',
+	'qw' => 'QuoteLike::Words',
+	'qr' => 'QuoteLike::Regexp',
+	'm'  => 'Regexp::Match',
+	's'  => 'Regexp::Substitute',
+	'tr' => 'Regexp::Transliterate',
+	'y'  => 'Regexp::Transliterate',
+);
+
+# List of keywords is from regen/keywords.pl in the perl source.
+our %KEYWORDS = map { $_ => 1 } qw{
+	abs accept alarm and atan2 bind binmode bless break caller chdir chmod
+	chomp chop chown chr chroot close closedir cmp connect continue cos
+	crypt dbmclose dbmopen default defined delete die do dump each else
+	elsif endgrent endhostent endnetent endprotoent endpwent endservent
+	eof eq eval evalbytes exec exists exit exp fc fcntl fileno flock for
+	foreach fork format formline ge getc getgrent getgrgid getgrnam
+	gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr
+	getnetbyname getnetent getpeername getpgrp getppid getpriority
+	getprotobyname getprotobynumber getprotoent getpwent getpwnam
+	getpwuid getservbyname getservbyport getservent getsockname
+	getsockopt given glob gmtime goto grep gt hex if index int ioctl join
+	keys kill last lc lcfirst le length link listen local localtime lock
+	log lstat lt m map mkdir msgctl msgget msgrcv msgsnd my ne next no
+	not oct open opendir or ord our pack package pipe pop pos print
+	printf prototype push q qq qr quotemeta qw qx rand read readdir
+	readline readlink readpipe recv redo ref rename require reset return
+	reverse rewinddir rindex rmdir s say scalar seek seekdir select semctl
+	semget semop send setgrent sethostent setnetent setpgrp
+	setpriority setprotoent setpwent setservent setsockopt shift shmctl
+	shmget shmread shmwrite shutdown sin sleep socket socketpair sort
+	splice split sprintf sqrt srand stat state study sub substr symlink
+	syscall sysopen sysread sysseek system syswrite tell telldir tie tied
+	time times tr truncate uc ucfirst umask undef unless unlink unpack
+	unshift untie until use utime values vec wait waitpid wantarray warn
+	when while write x xor y
+};
+
+1;

--- a/lib/PPI/Statement.pm
+++ b/lib/PPI/Statement.pm
@@ -151,17 +151,11 @@ use Scalar::Util   ();
 use Params::Util   qw{_INSTANCE};
 use PPI::Node      ();
 use PPI::Exception ();
+use PPI::Singletons '%_PARENT';
 
 our $VERSION = '1.236';
 
 our @ISA = "PPI::Node";
-
-our %_PARENT;
-BEGIN {
-	# Faster than having another method call just
-	# to set the structure finish token.
-	*_PARENT = *PPI::Element::_PARENT;
-}
 
 use PPI::Statement::Break          ();
 use PPI::Statement::Compound       ();

--- a/lib/PPI/Statement.pm
+++ b/lib/PPI/Statement.pm
@@ -154,9 +154,12 @@ use PPI::Exception ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA *_PARENT};
+our @ISA = "PPI::Node";
+
+our %_PARENT;
 BEGIN {
-	@ISA     = 'PPI::Node';
+	# Faster than having another method call just
+	# to set the structure finish token.
 	*_PARENT = *PPI::Element::_PARENT;
 }
 

--- a/lib/PPI/Statement/Break.pm
+++ b/lib/PPI/Statement/Break.pm
@@ -42,10 +42,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 1;
 

--- a/lib/PPI/Statement/Compound.pm
+++ b/lib/PPI/Statement/Compound.pm
@@ -58,7 +58,7 @@ our $VERSION = '1.236';
 our @ISA = "PPI::Statement";
 
 # Keyword type map
-our %TYPES = (
+my %TYPES = (
 	'if'      => 'if',
 	'unless'  => 'if',
 	'while'   => 'while',

--- a/lib/PPI/Statement/Compound.pm
+++ b/lib/PPI/Statement/Compound.pm
@@ -55,20 +55,17 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA %TYPES};
-BEGIN {
-	@ISA     = 'PPI::Statement';
+our @ISA = "PPI::Statement";
 
-	# Keyword type map
-	%TYPES = (
-		'if'      => 'if',
-		'unless'  => 'if',
-		'while'   => 'while',
-		'until'   => 'while',
-		'for'     => 'for',
-		'foreach' => 'foreach',
-	);
-}
+# Keyword type map
+our %TYPES = (
+	'if'      => 'if',
+	'unless'  => 'if',
+	'while'   => 'while',
+	'until'   => 'while',
+	'for'     => 'for',
+	'foreach' => 'foreach',
+);
 
 # Lexer clues
 sub __LEXER__normal() { '' }

--- a/lib/PPI/Statement/Data.pm
+++ b/lib/PPI/Statement/Data.pm
@@ -45,10 +45,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 # Data is never complete
 sub _complete () { '' }

--- a/lib/PPI/Statement/End.pm
+++ b/lib/PPI/Statement/End.pm
@@ -49,10 +49,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 # Once we have an __END__ we're done
 sub _complete () { 1 }

--- a/lib/PPI/Statement/Expression.pm
+++ b/lib/PPI/Statement/Expression.pm
@@ -40,10 +40,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 1;
 

--- a/lib/PPI/Statement/Given.pm
+++ b/lib/PPI/Statement/Given.pm
@@ -36,10 +36,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 # Lexer clues
 sub __LEXER__normal() { '' }

--- a/lib/PPI/Statement/Include.pm
+++ b/lib/PPI/Statement/Include.pm
@@ -50,10 +50,7 @@ use PPI::Statement::Include::Perl6 ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 =pod
 

--- a/lib/PPI/Statement/Include/Perl6.pm
+++ b/lib/PPI/Statement/Include/Perl6.pm
@@ -43,10 +43,7 @@ use PPI::Statement::Include ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement::Include';
-}
+our @ISA = "PPI::Statement::Include";
 
 =pod
 

--- a/lib/PPI/Statement/Null.pm
+++ b/lib/PPI/Statement/Null.pm
@@ -45,10 +45,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 # A null statement is not significant
 sub significant() { '' }

--- a/lib/PPI/Statement/Package.pm
+++ b/lib/PPI/Statement/Package.pm
@@ -43,10 +43,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 # Lexer clues
 sub __LEXER__normal() { '' }

--- a/lib/PPI/Statement/Scheduled.pm
+++ b/lib/PPI/Statement/Scheduled.pm
@@ -58,10 +58,7 @@ use PPI::Statement::Sub ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement::Sub';
-}
+our @ISA = "PPI::Statement::Sub";
 
 sub __LEXER__normal() { '' }
 

--- a/lib/PPI/Statement/Sub.pm
+++ b/lib/PPI/Statement/Sub.pm
@@ -37,10 +37,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 # Lexer clue
 sub __LEXER__normal() { '' }

--- a/lib/PPI/Statement/Unknown.pm
+++ b/lib/PPI/Statement/Unknown.pm
@@ -37,10 +37,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 # If one of these ends up in the final document,
 # we're pretty much screwed. Just call it a day.

--- a/lib/PPI/Statement/UnmatchedBrace.pm
+++ b/lib/PPI/Statement/UnmatchedBrace.pm
@@ -49,10 +49,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 # Once we've hit a naked unmatched brace we can never truly be complete.
 # So instead we always just call it a day...

--- a/lib/PPI/Statement/Variable.pm
+++ b/lib/PPI/Statement/Variable.pm
@@ -44,10 +44,7 @@ use PPI::Statement::Expression ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement::Expression';
-}
+our @ISA = "PPI::Statement";
 
 =pod
 

--- a/lib/PPI/Statement/When.pm
+++ b/lib/PPI/Statement/When.pm
@@ -44,10 +44,7 @@ use PPI::Statement ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Statement';
-}
+our @ISA = "PPI::Statement";
 
 # Lexer clues
 sub __LEXER__normal() { '' }

--- a/lib/PPI/Structure.pm
+++ b/lib/PPI/Structure.pm
@@ -93,17 +93,11 @@ use Scalar::Util   ();
 use Params::Util   qw{_INSTANCE};
 use PPI::Node      ();
 use PPI::Exception ();
+use PPI::Singletons '%_PARENT';
 
 our $VERSION = '1.236';
 
 our @ISA = "PPI::Node";
-
-our %_PARENT;
-BEGIN {
-	# Faster than having another method call just
-	# to set the structure finish token.
-	*_PARENT = *PPI::Element::_PARENT;
-}
 
 use PPI::Structure::Block       ();
 use PPI::Structure::Condition   ();

--- a/lib/PPI/Structure.pm
+++ b/lib/PPI/Structure.pm
@@ -96,9 +96,12 @@ use PPI::Exception ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA *_PARENT};
+our @ISA = "PPI::Node";
+
+our %_PARENT;
 BEGIN {
-	@ISA     = 'PPI::Node';
+	# Faster than having another method call just
+	# to set the structure finish token.
 	*_PARENT = *PPI::Element::_PARENT;
 }
 

--- a/lib/PPI/Structure/Block.pm
+++ b/lib/PPI/Structure/Block.pm
@@ -45,10 +45,7 @@ use PPI::Structure ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Structure';
-}
+our @ISA = "PPI::Structure";
 
 
 

--- a/lib/PPI/Structure/Condition.pm
+++ b/lib/PPI/Structure/Condition.pm
@@ -40,10 +40,7 @@ use PPI::Structure ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Structure';
-}
+our @ISA = "PPI::Structure";
 
 1;
 

--- a/lib/PPI/Structure/Constructor.pm
+++ b/lib/PPI/Structure/Constructor.pm
@@ -35,10 +35,7 @@ use PPI::Structure ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Structure';
-}
+our @ISA = "PPI::Structure";
 
 1;
 

--- a/lib/PPI/Structure/For.pm
+++ b/lib/PPI/Structure/For.pm
@@ -36,10 +36,7 @@ use PPI::Structure ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Structure';
-}
+our @ISA = "PPI::Structure";
 
 # Highly special custom isa method that will continue to respond
 # positively to ->isa('PPI::Structure::ForLoop') but warns.

--- a/lib/PPI/Structure/Given.pm
+++ b/lib/PPI/Structure/Given.pm
@@ -36,10 +36,7 @@ use PPI::Structure ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Structure';
-}
+our @ISA = "PPI::Structure";
 
 1;
 

--- a/lib/PPI/Structure/List.pm
+++ b/lib/PPI/Structure/List.pm
@@ -39,10 +39,7 @@ use PPI::Structure ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Structure';
-}
+our @ISA = "PPI::Structure";
 
 # Highly special custom isa method that will continue to respond
 # positively to ->isa('PPI::Structure::ForLoop') but warns.

--- a/lib/PPI/Structure/Subscript.pm
+++ b/lib/PPI/Structure/Subscript.pm
@@ -41,10 +41,7 @@ use PPI::Structure ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Structure';
-}
+our @ISA = "PPI::Structure";
 
 1;
 

--- a/lib/PPI/Structure/Unknown.pm
+++ b/lib/PPI/Structure/Unknown.pm
@@ -42,10 +42,7 @@ use PPI::Structure ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Structure';
-}
+our @ISA = "PPI::Structure";
 
 1;
 

--- a/lib/PPI/Structure/When.pm
+++ b/lib/PPI/Structure/When.pm
@@ -36,10 +36,7 @@ use PPI::Structure ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Structure';
-}
+our @ISA = "PPI::Structure";
 
 1;
 

--- a/lib/PPI/Token.pm
+++ b/lib/PPI/Token.pm
@@ -27,10 +27,7 @@ use PPI::Exception ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Element';
-}
+our @ISA = 'PPI::Element';
 
 # We don't load the abstracts, they are loaded
 # as part of the inheritance process.

--- a/lib/PPI/Token/ArrayIndex.pm
+++ b/lib/PPI/Token/ArrayIndex.pm
@@ -29,10 +29,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 

--- a/lib/PPI/Token/Attribute.pm
+++ b/lib/PPI/Token/Attribute.pm
@@ -35,10 +35,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 

--- a/lib/PPI/Token/BOM.pm
+++ b/lib/PPI/Token/BOM.pm
@@ -44,10 +44,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 sub significant() { '' }
 

--- a/lib/PPI/Token/Cast.pm
+++ b/lib/PPI/Token/Cast.pm
@@ -34,10 +34,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 

--- a/lib/PPI/Token/Comment.pm
+++ b/lib/PPI/Token/Comment.pm
@@ -63,10 +63,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 ### XS -> PPI/XS.xs:_PPI_Token_Comment__significant 0.900+
 sub significant() { '' }

--- a/lib/PPI/Token/DashedWord.pm
+++ b/lib/PPI/Token/DashedWord.pm
@@ -31,10 +31,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 =pod
 

--- a/lib/PPI/Token/Data.pm
+++ b/lib/PPI/Token/Data.pm
@@ -33,10 +33,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 

--- a/lib/PPI/Token/End.pm
+++ b/lib/PPI/Token/End.pm
@@ -45,10 +45,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 

--- a/lib/PPI/Token/HereDoc.pm
+++ b/lib/PPI/Token/HereDoc.pm
@@ -89,10 +89,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 

--- a/lib/PPI/Token/Label.pm
+++ b/lib/PPI/Token/Label.pm
@@ -31,10 +31,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 1;
 

--- a/lib/PPI/Token/Magic.pm
+++ b/lib/PPI/Token/Magic.pm
@@ -47,28 +47,23 @@ use PPI::Token::Unknown ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA %magic};
-BEGIN {
-	@ISA     = 'PPI::Token::Symbol';
+our @ISA = "PPI::Token::Symbol";
 
-	# Magic variables taken from perlvar.
-	# Several things added separately to avoid warnings.
-	foreach ( qw{
-		$1 $2 $3 $4 $5 $6 $7 $8 $9
-		$_ $& $` $' $+ @+ %+ $* $. $/ $|
-		$\\ $" $; $% $= $- @- %- $)
-		$~ $^ $: $? $! %! $@ $$ $< $>
-		$( $0 $[ $] @_ @*
+# Magic variables taken from perlvar.
+# Several things added separately to avoid warnings.
+our %magic = map { $_ => 1 } qw{
+	$1 $2 $3 $4 $5 $6 $7 $8 $9
+	$_ $& $` $' $+ @+ %+ $* $. $/ $|
+	$\\ $" $; $% $= $- @- %- $)
+	$~ $^ $: $? $! %! $@ $$ $< $>
+	$( $0 $[ $] @_ @*
 
-		$^L $^A $^E $^C $^D $^F $^H
-		$^I $^M $^N $^O $^P $^R $^S
-		$^T $^V $^W $^X %^H
+	$^L $^A $^E $^C $^D $^F $^H
+	$^I $^M $^N $^O $^P $^R $^S
+	$^T $^V $^W $^X %^H
 
-		$::|
-	}, '$}', '$,', '$#', '$#+', '$#-' ) {
-		$magic{$_} = 1;
-	}
-}
+	$::|
+}, '$}', '$,', '$#', '$#+', '$#-';
 
 
 sub __TOKENIZER__on_char {

--- a/lib/PPI/Token/Number.pm
+++ b/lib/PPI/Token/Number.pm
@@ -34,10 +34,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 =pod
 

--- a/lib/PPI/Token/Number/Binary.pm
+++ b/lib/PPI/Token/Number/Binary.pm
@@ -31,10 +31,7 @@ use PPI::Token::Number ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token::Number';
-}
+our @ISA = "PPI::Token::Number";
 
 =pod
 

--- a/lib/PPI/Token/Number/Exp.pm
+++ b/lib/PPI/Token/Number/Exp.pm
@@ -33,10 +33,7 @@ use PPI::Token::Number::Float ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token::Number::Float';
-}
+our @ISA = "PPI::Token::Number::Float";
 
 =pod
 

--- a/lib/PPI/Token/Number/Float.pm
+++ b/lib/PPI/Token/Number/Float.pm
@@ -33,10 +33,7 @@ use PPI::Token::Number ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token::Number';
-}
+our @ISA = "PPI::Token::Number";
 
 =pod
 

--- a/lib/PPI/Token/Number/Hex.pm
+++ b/lib/PPI/Token/Number/Hex.pm
@@ -31,10 +31,7 @@ use PPI::Token::Number ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token::Number';
-}
+our @ISA = "PPI::Token::Number";
 
 =pod
 

--- a/lib/PPI/Token/Number/Octal.pm
+++ b/lib/PPI/Token/Number/Octal.pm
@@ -31,10 +31,7 @@ use PPI::Token::Number ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token::Number';
-}
+our @ISA = "PPI::Token::Number";
 
 =pod
 

--- a/lib/PPI/Token/Number/Version.pm
+++ b/lib/PPI/Token/Number/Version.pm
@@ -35,10 +35,7 @@ use PPI::Token::Number ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token::Number';
-}
+our @ISA = "PPI::Token::Number";
 
 =pod
 

--- a/lib/PPI/Token/Operator.pm
+++ b/lib/PPI/Token/Operator.pm
@@ -41,28 +41,11 @@ L<PPI::Token> and L<PPI::Element> classes.
 
 use strict;
 use PPI::Token ();
+use PPI::Singletons '%OPERATOR';
 
 our $VERSION = '1.236';
 
 our @ISA = "PPI::Token";
-
-# Build the operator index
-### NOTE - This is accessed several times explicitly
-###        in PPI::Token::Word. Do not rename this
-###        without also correcting them.
-our %OPERATOR = map { $_ => 1 } (
-	qw{
-	-> ++ -- ** ! ~ + -
-	=~ !~ * / % x . << >>
-	< > <= >= lt gt le ge
-	== != <=> eq ne cmp ~~
-	& | ^ && || // .. ...
-	? :
-	= **= += -= .= *= /= %= x= &= |= ^= <<= >>= &&= ||= //=
-	=> <>
-	and or xor not
-	}, ',' 	# Avoids "comma in qw{}" warning
-);
 
 
 

--- a/lib/PPI/Token/Operator.pm
+++ b/lib/PPI/Token/Operator.pm
@@ -44,28 +44,25 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA %OPERATOR};
-BEGIN {
-	@ISA     = 'PPI::Token';
+our @ISA = "PPI::Token";
 
-	# Build the operator index
-	### NOTE - This is accessed several times explicitly
-	###        in PPI::Token::Word. Do not rename this
-	###        without also correcting them.
-	%OPERATOR = map { $_ => 1 } (
-		qw{
-		-> ++ -- ** ! ~ + -
-		=~ !~ * / % x . << >>
-		< > <= >= lt gt le ge
-		== != <=> eq ne cmp ~~
-		& | ^ && || // .. ...
-		? :
-		= **= += -= .= *= /= %= x= &= |= ^= <<= >>= &&= ||= //=
-		=> <>
-		and or xor not
-		}, ',' 	# Avoids "comma in qw{}" warning
-		);
-}
+# Build the operator index
+### NOTE - This is accessed several times explicitly
+###        in PPI::Token::Word. Do not rename this
+###        without also correcting them.
+our %OPERATOR = map { $_ => 1 } (
+	qw{
+	-> ++ -- ** ! ~ + -
+	=~ !~ * / % x . << >>
+	< > <= >= lt gt le ge
+	== != <=> eq ne cmp ~~
+	& | ^ && || // .. ...
+	? :
+	= **= += -= .= *= /= %= x= &= |= ^= <<= >>= &&= ||= //=
+	=> <>
+	and or xor not
+	}, ',' 	# Avoids "comma in qw{}" warning
+);
 
 
 

--- a/lib/PPI/Token/Pod.pm
+++ b/lib/PPI/Token/Pod.pm
@@ -30,10 +30,7 @@ use PPI::Token   ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 

--- a/lib/PPI/Token/Prototype.pm
+++ b/lib/PPI/Token/Prototype.pm
@@ -51,10 +51,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 sub __TOKENIZER__on_char {
 	my $class = shift;

--- a/lib/PPI/Token/Quote.pm
+++ b/lib/PPI/Token/Quote.pm
@@ -50,10 +50,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 

--- a/lib/PPI/Token/Quote/Double.pm
+++ b/lib/PPI/Token/Quote/Double.pm
@@ -36,13 +36,10 @@ use PPI::Token::_QuoteEngine::Simple ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Simple
-		PPI::Token::Quote
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Simple
+	PPI::Token::Quote
+};
 
 
 

--- a/lib/PPI/Token/Quote/Interpolate.pm
+++ b/lib/PPI/Token/Quote/Interpolate.pm
@@ -32,13 +32,10 @@ use PPI::Token::_QuoteEngine::Full ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Full
-		PPI::Token::Quote
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Full
+	PPI::Token::Quote
+};
 
 
 

--- a/lib/PPI/Token/Quote/Literal.pm
+++ b/lib/PPI/Token/Quote/Literal.pm
@@ -32,13 +32,10 @@ use PPI::Token::_QuoteEngine::Full ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Full
-		PPI::Token::Quote
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Full
+	PPI::Token::Quote
+};
 
 
 

--- a/lib/PPI/Token/Quote/Single.pm
+++ b/lib/PPI/Token/Quote/Single.pm
@@ -38,13 +38,10 @@ use PPI::Token::_QuoteEngine::Simple ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Simple
-		PPI::Token::Quote
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Simple
+	PPI::Token::Quote
+};
 
 
 

--- a/lib/PPI/Token/QuoteLike.pm
+++ b/lib/PPI/Token/QuoteLike.pm
@@ -50,10 +50,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 1;
 

--- a/lib/PPI/Token/QuoteLike/Backtick.pm
+++ b/lib/PPI/Token/QuoteLike/Backtick.pm
@@ -32,13 +32,10 @@ use PPI::Token::_QuoteEngine::Simple ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Simple
-		PPI::Token::QuoteLike
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Simple
+	PPI::Token::QuoteLike
+};
 
 1;
 

--- a/lib/PPI/Token/QuoteLike/Command.pm
+++ b/lib/PPI/Token/QuoteLike/Command.pm
@@ -32,13 +32,10 @@ use PPI::Token::_QuoteEngine::Full ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Full
-		PPI::Token::QuoteLike
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Full
+	PPI::Token::QuoteLike
+};
 
 1;
 

--- a/lib/PPI/Token/QuoteLike/Readline.pm
+++ b/lib/PPI/Token/QuoteLike/Readline.pm
@@ -41,13 +41,10 @@ use PPI::Token::_QuoteEngine::Full ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Full
-		PPI::Token::QuoteLike
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Full
+	PPI::Token::QuoteLike
+};
 
 1;
 

--- a/lib/PPI/Token/QuoteLike/Regexp.pm
+++ b/lib/PPI/Token/QuoteLike/Regexp.pm
@@ -35,13 +35,10 @@ use PPI::Token::_QuoteEngine::Full ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Full
-		PPI::Token::QuoteLike
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Full
+	PPI::Token::QuoteLike
+};
 
 
 

--- a/lib/PPI/Token/QuoteLike/Words.pm
+++ b/lib/PPI/Token/QuoteLike/Words.pm
@@ -31,13 +31,10 @@ use PPI::Token::_QuoteEngine::Full ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Full
-		PPI::Token::QuoteLike
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Full
+	PPI::Token::QuoteLike
+};
 
 =pod
 

--- a/lib/PPI/Token/Regexp.pm
+++ b/lib/PPI/Token/Regexp.pm
@@ -47,10 +47,7 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 

--- a/lib/PPI/Token/Regexp/Match.pm
+++ b/lib/PPI/Token/Regexp/Match.pm
@@ -46,13 +46,10 @@ use PPI::Token::_QuoteEngine::Full ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Full
-		PPI::Token::Regexp
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Full
+	PPI::Token::Regexp
+};
 
 1;
 

--- a/lib/PPI/Token/Regexp/Substitute.pm
+++ b/lib/PPI/Token/Regexp/Substitute.pm
@@ -36,13 +36,10 @@ use PPI::Token::_QuoteEngine::Full ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Full
-		PPI::Token::Regexp
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Full
+	PPI::Token::Regexp
+};
 
 1;
 

--- a/lib/PPI/Token/Regexp/Transliterate.pm
+++ b/lib/PPI/Token/Regexp/Transliterate.pm
@@ -40,13 +40,10 @@ use PPI::Token::_QuoteEngine::Full ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = qw{
-		PPI::Token::_QuoteEngine::Full
-		PPI::Token::Regexp
-	};
-}
+our @ISA = qw{
+	PPI::Token::_QuoteEngine::Full
+	PPI::Token::Regexp
+};
 
 1;
 

--- a/lib/PPI/Token/Separator.pm
+++ b/lib/PPI/Token/Separator.pm
@@ -37,10 +37,7 @@ use PPI::Token::Word ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token::Word';
-}
+our @ISA = "PPI::Token";
 
 1;
 

--- a/lib/PPI/Token/Structure.pm
+++ b/lib/PPI/Token/Structure.pm
@@ -33,30 +33,28 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 # Set the matching braces, done as an array
 # for slightly faster lookups.
-use vars qw{@MATCH @OPENS @CLOSES};
-BEGIN {
-	$MATCH[ord '{']  = '}';
-	$MATCH[ord '}']  = '{';
-	$MATCH[ord '[']  = ']';
-	$MATCH[ord ']']  = '[';
-	$MATCH[ord '(']  = ')';
-	$MATCH[ord ')']  = '(';
-
-	$OPENS[ord '{']  = 1;
-	$OPENS[ord '[']  = 1;
-	$OPENS[ord '(']  = 1;
-
-	$CLOSES[ord '}'] = 1;
-	$CLOSES[ord ']'] = 1;
-	$CLOSES[ord ')'] = 1;
-}
+our %MATCH = (
+	ord '{' => '}',
+	ord '}' => '{',
+	ord '[' => ']',
+	ord ']' => '[',
+	ord '(' => ')',
+	ord ')' => '(',
+);
+our %OPENS = (
+	ord '{' => 1,
+	ord '[' => 1,
+	ord '(' => 1,
+);
+our %CLOSES = (
+	ord '}' => 1,
+	ord ']' => 1,
+	ord ')' => 1,
+);
 
 
 
@@ -87,7 +85,7 @@ sub __TOKENIZER__commit {
 
 # For a given brace, find its opposing pair
 sub __LEXER__opposite {
-	$MATCH[ord $_[0]->{content} ];
+	$MATCH{ord $_[0]->{content}};
 }
 
 
@@ -137,7 +135,7 @@ sub next_token {
 
 	# If this is an opening brace, descend down into our parent
 	# structure, if it has children.
-	if ( $OPENS[ ord $self->{content} ] ) {
+	if ( $OPENS{ ord $self->{content} } ) {
 		my $child = $structure->child(0);
 		if ( $child ) {
 			# Decend deeper, or return if it is a token
@@ -165,7 +163,7 @@ sub previous_token {
 
 	# If this is a closing brace, descend down into our parent
 	# structure, if it has children.
-	if ( $CLOSES[ ord $self->{content} ] ) {
+	if ( $CLOSES{ ord $self->{content} } ) {
 		my $child = $structure->child(-1);
 		if ( $child ) {
 			# Decend deeper, or return if it is a token

--- a/lib/PPI/Token/Structure.pm
+++ b/lib/PPI/Token/Structure.pm
@@ -37,7 +37,7 @@ our @ISA = "PPI::Token";
 
 # Set the matching braces, done as an array
 # for slightly faster lookups.
-our %MATCH = (
+my %MATCH = (
 	ord '{' => '}',
 	ord '}' => '{',
 	ord '[' => ']',
@@ -45,12 +45,12 @@ our %MATCH = (
 	ord '(' => ')',
 	ord ')' => '(',
 );
-our %OPENS = (
+my %OPENS = (
 	ord '{' => 1,
 	ord '[' => 1,
 	ord '(' => 1,
 );
-our %CLOSES = (
+my %CLOSES = (
 	ord '}' => 1,
 	ord ']' => 1,
 	ord ')' => 1,

--- a/lib/PPI/Token/Symbol.pm
+++ b/lib/PPI/Token/Symbol.pm
@@ -33,10 +33,7 @@ use PPI::Token   ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token';
-}
+our @ISA = "PPI::Token";
 
 
 
@@ -200,7 +197,7 @@ sub __TOKENIZER__on_char {
 	# Trim off anything we oversucked...
 	$content =~ /^(
 		[\$@%&*]
-		(?: : (?!:) | # Allow single-colon non-magic vars
+		(?: : (?!:) | # Allow single-colon non-magic variables
 			(?: \w+ | \' (?!\d) \w+ | \:: \w+ )
 			(?:
 				# Allow both :: and ' in namespace separators

--- a/lib/PPI/Token/Unknown.pm
+++ b/lib/PPI/Token/Unknown.pm
@@ -33,11 +33,8 @@ use PPI::Exception ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA $CURLY_SYMBOL};
-BEGIN {
-	@ISA     = 'PPI::Token';
-	$CURLY_SYMBOL = qr{\G\^[[:upper:]_]\w+\}};
-}
+our ( $CURLY_SYMBOL, @ISA ) = ( qr{\G\^[[:upper:]_]\w+\}}, "PPI::Token" );
+
 
 
 

--- a/lib/PPI/Token/Unknown.pm
+++ b/lib/PPI/Token/Unknown.pm
@@ -30,10 +30,11 @@ object as a bug.
 use strict;
 use PPI::Token     ();
 use PPI::Exception ();
+use PPI::Singletons qw' %MAGIC $CURLY_SYMBOL ';
 
 our $VERSION = '1.236';
 
-our ( $CURLY_SYMBOL, @ISA ) = ( qr{\G\^[[:upper:]_]\w+\}}, "PPI::Token" );
+our @ISA = "PPI::Token";
 
 
 
@@ -96,7 +97,7 @@ sub __TOKENIZER__on_char {
 			return 1;
 		}
 
-		if ( $PPI::Token::Magic::magic{ $c . $char } ) {
+		if ( $MAGIC{ $c . $char } ) {
 			# Magic variable
 			$t->{class} = $t->{token}->set_class( 'Magic' );
 			return 1;
@@ -125,7 +126,7 @@ sub __TOKENIZER__on_char {
 			return 1;
 		}
 
-		if ( $PPI::Token::Magic::magic{ $c . $char } ) {
+		if ( $MAGIC{ $c . $char } ) {
 			# Magic variable
 			$t->{class} = $t->{token}->set_class( 'Magic' );
 			return 1;
@@ -156,7 +157,7 @@ sub __TOKENIZER__on_char {
 		}
 
 		# Is it a magic variable?
-		if ( $char eq '^' || $PPI::Token::Magic::magic{ $c . $char } ) {
+		if ( $char eq '^' || $MAGIC{ $c . $char } ) {
 			$t->{class} = $t->{token}->set_class( 'Magic' );
 			return 1;
 		}

--- a/lib/PPI/Token/Whitespace.pm
+++ b/lib/PPI/Token/Whitespace.pm
@@ -114,7 +114,7 @@ my %COMMITMAP = (
 	ord '#' => 'PPI::Token::Comment',
 	ord 'v' => 'PPI::Token::Number::Version',
 );
-our %CLASSMAP = (
+my %CLASSMAP = (
 	map( { ord $_ => 'Number' } 0 .. 9 ),
 	map( { ord $_ => 'Operator' } qw" = ? | + > . ! ~ ^ " ),
 	map( { ord $_ => 'Unknown' } qw" * $ @ & : % " ),
@@ -133,7 +133,7 @@ our %CLASSMAP = (
 
 # Words (functions and keywords) after which a following / is
 # almost certainly going to be a regex
-our %MATCHWORD = map { $_ => 1 } qw{
+my %MATCHWORD = map { $_ => 1 } qw{
   return
   split
   if

--- a/lib/PPI/Token/Word.pm
+++ b/lib/PPI/Token/Word.pm
@@ -40,54 +40,54 @@ use PPI::Token ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA %OPERATOR %QUOTELIKE %KEYWORDS};
-BEGIN {
-	@ISA     = 'PPI::Token';
+our @ISA = "PPI::Token";
 
+our %OPERATOR;
+BEGIN {
 	# Copy in OPERATOR from PPI::Token::Operator
 	*OPERATOR  = *PPI::Token::Operator::OPERATOR;
-
-	%QUOTELIKE = (
-		'q'  => 'Quote::Literal',
-		'qq' => 'Quote::Interpolate',
-		'qx' => 'QuoteLike::Command',
-		'qw' => 'QuoteLike::Words',
-		'qr' => 'QuoteLike::Regexp',
-		'm'  => 'Regexp::Match',
-		's'  => 'Regexp::Substitute',
-		'tr' => 'Regexp::Transliterate',
-		'y'  => 'Regexp::Transliterate',
-	);
-
-	# List of keywords is from regen/keywords.pl in the perl source.
-	%KEYWORDS = map { $_ => 1 } qw{
-		abs accept alarm and atan2 bind binmode bless break caller chdir chmod
-		chomp chop chown chr chroot close closedir cmp connect continue cos
-		crypt dbmclose dbmopen default defined delete die do dump each else
-		elsif endgrent endhostent endnetent endprotoent endpwent endservent
-		eof eq eval evalbytes exec exists exit exp fc fcntl fileno flock for
-		foreach fork format formline ge getc getgrent getgrgid getgrnam
-		gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr
-		getnetbyname getnetent getpeername getpgrp getppid getpriority
-		getprotobyname getprotobynumber getprotoent getpwent getpwnam
-		getpwuid getservbyname getservbyport getservent getsockname
-		getsockopt given glob gmtime goto grep gt hex if index int ioctl join
-		keys kill last lc lcfirst le length link listen local localtime lock
-		log lstat lt m map mkdir msgctl msgget msgrcv msgsnd my ne next no
-		not oct open opendir or ord our pack package pipe pop pos print
-		printf prototype push q qq qr quotemeta qw qx rand read readdir
-		readline readlink readpipe recv redo ref rename require reset return
-		reverse rewinddir rindex rmdir s say scalar seek seekdir select semctl
-		semget semop send setgrent sethostent setnetent setpgrp
-		setpriority setprotoent setpwent setservent setsockopt shift shmctl
-		shmget shmread shmwrite shutdown sin sleep socket socketpair sort
-		splice split sprintf sqrt srand stat state study sub substr symlink
-		syscall sysopen sysread sysseek system syswrite tell telldir tie tied
-		time times tr truncate uc ucfirst umask undef unless unlink unpack
-		unshift untie until use utime values vec wait waitpid wantarray warn
-		when while write x xor y
-	};
 }
+
+our %QUOTELIKE = (
+	'q'  => 'Quote::Literal',
+	'qq' => 'Quote::Interpolate',
+	'qx' => 'QuoteLike::Command',
+	'qw' => 'QuoteLike::Words',
+	'qr' => 'QuoteLike::Regexp',
+	'm'  => 'Regexp::Match',
+	's'  => 'Regexp::Substitute',
+	'tr' => 'Regexp::Transliterate',
+	'y'  => 'Regexp::Transliterate',
+);
+
+# List of keywords is from regen/keywords.pl in the perl source.
+our %KEYWORDS = map { $_ => 1 } qw{
+	abs accept alarm and atan2 bind binmode bless break caller chdir chmod
+	chomp chop chown chr chroot close closedir cmp connect continue cos
+	crypt dbmclose dbmopen default defined delete die do dump each else
+	elsif endgrent endhostent endnetent endprotoent endpwent endservent
+	eof eq eval evalbytes exec exists exit exp fc fcntl fileno flock for
+	foreach fork format formline ge getc getgrent getgrgid getgrnam
+	gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr
+	getnetbyname getnetent getpeername getpgrp getppid getpriority
+	getprotobyname getprotobynumber getprotoent getpwent getpwnam
+	getpwuid getservbyname getservbyport getservent getsockname
+	getsockopt given glob gmtime goto grep gt hex if index int ioctl join
+	keys kill last lc lcfirst le length link listen local localtime lock
+	log lstat lt m map mkdir msgctl msgget msgrcv msgsnd my ne next no
+	not oct open opendir or ord our pack package pipe pop pos print
+	printf prototype push q qq qr quotemeta qw qx rand read readdir
+	readline readlink readpipe recv redo ref rename require reset return
+	reverse rewinddir rindex rmdir s say scalar seek seekdir select semctl
+	semget semop send setgrent sethostent setnetent setpgrp
+	setpriority setprotoent setpwent setservent setsockopt shift shmctl
+	shmget shmread shmwrite shutdown sin sleep socket socketpair sort
+	splice split sprintf sqrt srand stat state study sub substr symlink
+	syscall sysopen sysread sysseek system syswrite tell telldir tie tied
+	time times tr truncate uc ucfirst umask undef unless unlink unpack
+	unshift untie until use utime values vec wait waitpid wantarray warn
+	when while write x xor y
+};
 
 =pod
 

--- a/lib/PPI/Token/Word.pm
+++ b/lib/PPI/Token/Word.pm
@@ -37,57 +37,11 @@ now, look at L<Perl::Critic::Utils>.
 
 use strict;
 use PPI::Token ();
+use PPI::Singletons qw' %OPERATOR %QUOTELIKE %KEYWORDS ';
 
 our $VERSION = '1.236';
 
 our @ISA = "PPI::Token";
-
-our %OPERATOR;
-BEGIN {
-	# Copy in OPERATOR from PPI::Token::Operator
-	*OPERATOR  = *PPI::Token::Operator::OPERATOR;
-}
-
-our %QUOTELIKE = (
-	'q'  => 'Quote::Literal',
-	'qq' => 'Quote::Interpolate',
-	'qx' => 'QuoteLike::Command',
-	'qw' => 'QuoteLike::Words',
-	'qr' => 'QuoteLike::Regexp',
-	'm'  => 'Regexp::Match',
-	's'  => 'Regexp::Substitute',
-	'tr' => 'Regexp::Transliterate',
-	'y'  => 'Regexp::Transliterate',
-);
-
-# List of keywords is from regen/keywords.pl in the perl source.
-our %KEYWORDS = map { $_ => 1 } qw{
-	abs accept alarm and atan2 bind binmode bless break caller chdir chmod
-	chomp chop chown chr chroot close closedir cmp connect continue cos
-	crypt dbmclose dbmopen default defined delete die do dump each else
-	elsif endgrent endhostent endnetent endprotoent endpwent endservent
-	eof eq eval evalbytes exec exists exit exp fc fcntl fileno flock for
-	foreach fork format formline ge getc getgrent getgrgid getgrnam
-	gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr
-	getnetbyname getnetent getpeername getpgrp getppid getpriority
-	getprotobyname getprotobynumber getprotoent getpwent getpwnam
-	getpwuid getservbyname getservbyport getservent getsockname
-	getsockopt given glob gmtime goto grep gt hex if index int ioctl join
-	keys kill last lc lcfirst le length link listen local localtime lock
-	log lstat lt m map mkdir msgctl msgget msgrcv msgsnd my ne next no
-	not oct open opendir or ord our pack package pipe pop pos print
-	printf prototype push q qq qr quotemeta qw qx rand read readdir
-	readline readlink readpipe recv redo ref rename require reset return
-	reverse rewinddir rindex rmdir s say scalar seek seekdir select semctl
-	semget semop send setgrent sethostent setnetent setpgrp
-	setpriority setprotoent setpwent setservent setsockopt shift shmctl
-	shmget shmread shmwrite shutdown sin sleep socket socketpair sort
-	splice split sprintf sqrt srand stat state study sub substr symlink
-	syscall sysopen sysread sysseek system syswrite tell telldir tie tied
-	time times tr truncate uc ucfirst umask undef unless unlink unpack
-	unshift untie until use utime values vec wait waitpid wantarray warn
-	when while write x xor y
-};
 
 =pod
 

--- a/lib/PPI/Token/_QuoteEngine/Full.pm
+++ b/lib/PPI/Token/_QuoteEngine/Full.pm
@@ -12,7 +12,7 @@ our $VERSION = '1.236';
 our @ISA = 'PPI::Token::_QuoteEngine';
 
 # Prototypes for the different braced sections
-our %sections = (
+my %SECTIONS = (
 	'(' => { type => '()', _close => ')' },
 	'<' => { type => '<>', _close => '>' },
 	'[' => { type => '[]', _close => ']' },
@@ -21,7 +21,7 @@ our %sections = (
 
 # For each quote type, the extra fields that should be set.
 # This should give us faster initialization.
-our %quotes = (
+my %QUOTES = (
 	'q'   => { operator => 'q',   braced => undef, separator => undef, _sections => 1 },
 	'qq'  => { operator => 'qq',  braced => undef, separator => undef, _sections => 1 },
 	'qx'  => { operator => 'qx',  braced => undef, separator => undef, _sections => 1 },
@@ -59,7 +59,7 @@ sub new {
 	my $self = PPI::Token::new( $class, $init ) or return undef;
 
 	# Do we have a prototype for the initializer? If so, add the extra fields
-	my $options = $quotes{$init} or return $self->_error(
+	my $options = $QUOTES{$init} or return $self->_error(
 		"Unknown quote type '$init'"
 	);
 	foreach ( keys %$options ) {
@@ -71,7 +71,7 @@ sub new {
 
 	# Handle the special < base
 	if ( $init eq '<' ) {
-		$self->{sections}->[0] = Clone::clone( $sections{'<'} );
+		$self->{sections}->[0] = Clone::clone( $SECTIONS{'<'} );
 	}
 
 	$self;
@@ -105,7 +105,7 @@ sub _fill {
 		$self->{content} .= $sep;
 
 		# Determine if these are normal or braced type sections
-		if ( my $section = $sections{$sep} ) {
+		if ( my $section = $SECTIONS{$sep} ) {
 			$self->{braced}        = 1;
 			$self->{sections}->[0] = Clone::clone($section);
 		} else {
@@ -267,7 +267,7 @@ sub _fill_braced {
 		$char = substr( $t->{line}, $t->{line_cursor}, 1 );
 	}
 
-	$section = $sections{$char};
+	$section = $SECTIONS{$char};
 
 	if ( $section ) {
 		# It's a brace

--- a/lib/PPI/Token/_QuoteEngine/Full.pm
+++ b/lib/PPI/Token/_QuoteEngine/Full.pm
@@ -9,44 +9,41 @@ use PPI::Token::_QuoteEngine ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA %quotes %sections};
-BEGIN {
-	@ISA     = 'PPI::Token::_QuoteEngine';
+our @ISA = 'PPI::Token::_QuoteEngine';
 
-	# Prototypes for the different braced sections
-	%sections = (
-		'(' => { type => '()', _close => ')' },
-		'<' => { type => '<>', _close => '>' },
-		'[' => { type => '[]', _close => ']' },
-		'{' => { type => '{}', _close => '}' },
-	);
+# Prototypes for the different braced sections
+our %sections = (
+	'(' => { type => '()', _close => ')' },
+	'<' => { type => '<>', _close => '>' },
+	'[' => { type => '[]', _close => ']' },
+	'{' => { type => '{}', _close => '}' },
+);
 
-	# For each quote type, the extra fields that should be set.
-	# This should give us faster initialization.
-	%quotes = (
-		'q'   => { operator => 'q',   braced => undef, separator => undef, _sections => 1 },
-		'qq'  => { operator => 'qq',  braced => undef, separator => undef, _sections => 1 },
-		'qx'  => { operator => 'qx',  braced => undef, separator => undef, _sections => 1 },
-		'qw'  => { operator => 'qw',  braced => undef, separator => undef, _sections => 1 },
-		'qr'  => { operator => 'qr',  braced => undef, separator => undef, _sections => 1, modifiers => 1 },
-		'm'   => { operator => 'm',   braced => undef, separator => undef, _sections => 1, modifiers => 1 },
-		's'   => { operator => 's',   braced => undef, separator => undef, _sections => 2, modifiers => 1 },
-		'tr'  => { operator => 'tr',  braced => undef, separator => undef, _sections => 2, modifiers => 1 },
+# For each quote type, the extra fields that should be set.
+# This should give us faster initialization.
+our %quotes = (
+	'q'   => { operator => 'q',   braced => undef, separator => undef, _sections => 1 },
+	'qq'  => { operator => 'qq',  braced => undef, separator => undef, _sections => 1 },
+	'qx'  => { operator => 'qx',  braced => undef, separator => undef, _sections => 1 },
+	'qw'  => { operator => 'qw',  braced => undef, separator => undef, _sections => 1 },
+	'qr'  => { operator => 'qr',  braced => undef, separator => undef, _sections => 1, modifiers => 1 },
+	'm'   => { operator => 'm',   braced => undef, separator => undef, _sections => 1, modifiers => 1 },
+	's'   => { operator => 's',   braced => undef, separator => undef, _sections => 2, modifiers => 1 },
+	'tr'  => { operator => 'tr',  braced => undef, separator => undef, _sections => 2, modifiers => 1 },
 
-		# Y is the little-used variant of tr
-		'y'   => { operator => 'y',   braced => undef, separator => undef, _sections => 2, modifiers => 1 },
+	# Y is the little-used variant of tr
+	'y'   => { operator => 'y',   braced => undef, separator => undef, _sections => 2, modifiers => 1 },
 
-		'/'   => { operator => undef, braced => 0,     separator => '/',   _sections => 1, modifiers => 1 },
+	'/'   => { operator => undef, braced => 0,     separator => '/',   _sections => 1, modifiers => 1 },
 
-		# Angle brackets quotes mean "readline(*FILEHANDLE)"
-		'<'   => { operator => undef, braced => 1,     separator => undef, _sections => 1, },
+	# Angle brackets quotes mean "readline(*FILEHANDLE)"
+	'<'   => { operator => undef, braced => 1,     separator => undef, _sections => 1, },
 
-		# The final ( and kind of depreciated ) "first match only" one is not
-		# used yet, since I'm not sure on the context differences between
-		# this and the trinary operator, but it's here for completeness.
-		'?'   => { operator => undef, braced => 0,     separator => '?',   _sections => 1, modifiers => 1 },
-	);
-}
+	# The final ( and kind of depreciated ) "first match only" one is not
+	# used yet, since I'm not sure on the context differences between
+	# this and the trinary operator, but it's here for completeness.
+	'?'   => { operator => undef, braced => 0,     separator => '?',   _sections => 1, modifiers => 1 },
+);
 
 
 sub new {

--- a/lib/PPI/Token/_QuoteEngine/Simple.pm
+++ b/lib/PPI/Token/_QuoteEngine/Simple.pm
@@ -7,10 +7,7 @@ use PPI::Token::_QuoteEngine ();
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA};
-BEGIN {
-	@ISA     = 'PPI::Token::_QuoteEngine';
-}
+our @ISA = 'PPI::Token::_QuoteEngine';
 
 sub new {
 	my $class     = shift;

--- a/lib/PPI/Util.pm
+++ b/lib/PPI/Util.pm
@@ -9,11 +9,8 @@ use Params::Util qw{_INSTANCE _SCALAR0 _ARRAY0};
 
 our $VERSION = '1.236';
 
-use vars qw{@ISA @EXPORT_OK};
-BEGIN {
-	@ISA       = 'Exporter';
-	@EXPORT_OK = qw{_Document _slurp};
-}
+our @ISA       = 'Exporter';
+our @EXPORT_OK = qw{ _Document _slurp };
 
 # 5.8.7 was the first version to resolve the notorious
 # "unicode length caching" bug.

--- a/t/04_element.t
+++ b/t/04_element.t
@@ -13,6 +13,7 @@ use File::Spec::Functions ':ALL';
 use PPI;
 use Scalar::Util 'refaddr';
 use PPI::Test 'pause';
+use PPI::Singletons '%_PARENT';
 
 our $RE_IDENTIFIER = qr/[^\W\d]\w*/;
 
@@ -409,60 +410,60 @@ ok( ! defined $Braces->parent, "Braces are detached from parent" );
 # Start with DESTROY for an element that never has a parent
 SCOPE: {
 	my $Token = PPI::Token::Whitespace->new( ' ' );
-	my $k1 = scalar keys %PPI::Element::_PARENT;
+	my $k1 = scalar keys %_PARENT;
 	$Token->DESTROY;
-	my $k2 = scalar keys %PPI::Element::_PARENT;
+	my $k2 = scalar keys %_PARENT;
 	is( $k1, $k2, '_PARENT key count remains unchanged after naked Element DESTROY' );
 }
 
 # Next, a single element within a parent
 SCOPE: {
-	my $k1 = scalar keys %PPI::Element::_PARENT;
+	my $k1 = scalar keys %_PARENT;
 	my $k2;
 	my $k3;
 	SCOPE: {
 		my $Token     = PPI::Token::Number->new( '1' );
 		my $Statement = PPI::Statement->new;
 		$Statement->add_element( $Token );
-		$k2 = scalar keys %PPI::Element::_PARENT;
+		$k2 = scalar keys %_PARENT;
 		is( $k2, $k1 + 1, 'PARENT keys increases after adding element' );
 		$Statement->DESTROY;
 	}
 	pause();
-	$k3 = scalar keys %PPI::Element::_PARENT;
+	$k3 = scalar keys %_PARENT;
 	is( $k3, $k1, 'PARENT keys returns to original on DESTROY' );
 }
 
 # Repeat for an entire (large) file
 SCOPE: {
-	my $k1 = scalar keys %PPI::Element::_PARENT;
+	my $k1 = scalar keys %_PARENT;
 	my $k2;
 	my $k3;
 	SCOPE: {
 		my $NodeDocument = PPI::Document->new( $INC{"PPI/Node.pm"} );
 		isa_ok( $NodeDocument, 'PPI::Document' );
-		$k2 = scalar keys %PPI::Element::_PARENT;
+		$k2 = scalar keys %_PARENT;
 		ok( $k2 > ($k1 + 3000), 'PARENT keys increases after loading document' );
 		$NodeDocument->DESTROY;
 	}
 	pause();
-	$k3 = scalar keys %PPI::Element::_PARENT;
+	$k3 = scalar keys %_PARENT;
 	is( $k3, $k1, 'PARENT keys returns to original on explicit Document DESTROY' );
 }
 
 # Repeat again, but with an implicit DESTROY
 SCOPE: {
-	my $k1 = scalar keys %PPI::Element::_PARENT;
+	my $k1 = scalar keys %_PARENT;
 	my $k2;
 	my $k3;
 	SCOPE: {
 		my $NodeDocument = PPI::Document->new( $INC{"PPI/Node.pm"} );
 		isa_ok( $NodeDocument, 'PPI::Document' );
-		$k2 = scalar keys %PPI::Element::_PARENT;
+		$k2 = scalar keys %_PARENT;
 		ok( $k2 > ($k1 + 3000), 'PARENT keys increases after loading document' );
 	}
 	pause();
-	$k3 = scalar keys %PPI::Element::_PARENT;
+	$k3 = scalar keys %_PARENT;
 	is( $k3, $k1, 'PARENT keys returns to original on implicit Document DESTROY' );
 }
 

--- a/t/04_element.t
+++ b/t/04_element.t
@@ -14,6 +14,7 @@ use PPI;
 use Scalar::Util 'refaddr';
 use PPI::Test 'pause';
 
+our $RE_IDENTIFIER = qr/[^\W\d]\w*/;
 
 sub is_object {
 	my ($left, $right, $message) = @_;
@@ -26,11 +27,6 @@ sub is_object {
 		and refaddr($left) == refaddr($right)
 		);
 	ok( $condition, $message );
-}
-
-use vars qw{$RE_IDENTIFIER};
-BEGIN {
-	$RE_IDENTIFIER = qr/[^\W\d]\w*/;
 }
 
 sub omethod_fails {

--- a/t/04_element.t
+++ b/t/04_element.t
@@ -15,7 +15,7 @@ use Scalar::Util 'refaddr';
 use PPI::Test 'pause';
 use PPI::Singletons '%_PARENT';
 
-our $RE_IDENTIFIER = qr/[^\W\d]\w*/;
+my $RE_IDENTIFIER = qr/[^\W\d]\w*/;
 
 sub is_object {
 	my ($left, $right, $message) = @_;

--- a/t/08_regression.t
+++ b/t/08_regression.t
@@ -11,6 +11,7 @@ use Test::More tests => 925 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 use PPI;
 use PPI::Test 'pause';
 use PPI::Test::Run;
+use PPI::Singletons '%_PARENT';
 
 
 
@@ -29,10 +30,10 @@ PPI::Test::Run->run_testdir(qw{ t data 08_regression });
 # Check that objects created in a foreach don't leak circulars.
 foreach ( 1 .. 3 ) {
 	pause();
-	is( scalar(keys(%PPI::Element::_PARENT)), 0, "No parent links at start of loop $_" );
+	is( scalar(keys(%_PARENT)), 0, "No parent links at start of loop $_" );
 	# Keep the document from going out of scope before the _PARENT test below.
 	my $Document = PPI::Document->new(\q[print "Foo!"]);  ## no critic ( Variables::ProhibitUnusedVarsStricter )
-	is( scalar(keys(%PPI::Element::_PARENT)), 4, 'Correct number of keys created' );
+	is( scalar(keys(%_PARENT)), 4, 'Correct number of keys created' );
 }
 
 

--- a/t/09_normal.t
+++ b/t/09_normal.t
@@ -9,6 +9,7 @@ use Test::More tests => 17 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI;
+use PPI::Singletons           '%LAYER';
 
 
 
@@ -56,8 +57,8 @@ SCOPE: {
 NO_DOUBLE_REG: {
 	sub just_a_test_sub { "meep" }
 	ok( PPI::Normal->register( "main::just_a_test_sub", 2 ), "can add subs" );
-	is $PPI::Normal::LAYER{2}[-1], "main::just_a_test_sub", "and find subs at right layer";
-	my $size = @{ $PPI::Normal::LAYER{2} };
+	is $LAYER{2}[-1], "main::just_a_test_sub", "and find subs at right layer";
+	my $size = @{ $LAYER{2} };
 	ok( PPI::Normal->register( "main::just_a_test_sub", 2 ), "can add subs again" );
-	is scalar @{ $PPI::Normal::LAYER{2} }, $size, "but sub isn't added twice";
+	is scalar @{ $LAYER{2} }, $size, "but sub isn't added twice";
 }

--- a/t/15_transform.t
+++ b/t/15_transform.t
@@ -119,9 +119,9 @@ package MyCleaner;
 use Params::Util   qw{_INSTANCE};
 use PPI::Transform ();
 
-use vars qw{@ISA};
+our @ISA;
 BEGIN {
-	@ISA = 'PPI::Transform';
+	@ISA = 'PPI::Transform'; # in a BEGIN block due to being an inline package
 }
 
 sub document {
@@ -137,10 +137,7 @@ sub new {
 	bless { }, 'Foo';
 }
 
-use vars qw{$VALUE};
-BEGIN {
-	$VALUE = '';
-}
+our $VALUE = '';
 
 sub get {
 	PPI::Document->new( \$VALUE );

--- a/t/21_exhaustive.t
+++ b/t/21_exhaustive.t
@@ -13,8 +13,8 @@ use PPI::Test 'quotable';
 # When distributing, keep this in to verify the test script
 # is working correctly, but limit to 2 (maaaaybe 3) so we
 # don't slow the install process down too much.
-our ( $MAX_CHARS, $ITERATIONS, $LENGTH )  = ( 2, 1000, 190 );
-our @ALL_CHARS = (
+my ( $MAX_CHARS, $ITERATIONS, $LENGTH )  = ( 2, 1000, 190 );
+my @ALL_CHARS = (
 	qw{a b c f g m q r s t w x y z V W X 0 1 8 9},
 	';', '[', ']', '{', '}', '(', ')', '=', '?', '|', '+', '<',
 	'>', '.', '!', '~', '^', '*', '$', '@', '&', ':', '%', ',',
@@ -23,7 +23,7 @@ our @ALL_CHARS = (
 );
 
 # Cases known to have failed in the past.
-our @FAILURES = (
+my @FAILURES = (
 	# Failed cases 3 chars or less
 	'!%:', '!%:',  '!%:',  '!%:',  '!*:', '!@:',  '%:',  '%:,',
 	'%:;', '*:',   '*:,',  '*::',  '*:;', '+%:',  '+*:', '+@:',

--- a/t/21_exhaustive.t
+++ b/t/21_exhaustive.t
@@ -10,60 +10,48 @@ use Params::Util qw{_INSTANCE};
 use PPI;
 use PPI::Test 'quotable';
 
-use vars qw{$MAX_CHARS $ITERATIONS $LENGTH @ALL_CHARS @FAILURES};
-BEGIN {
-	# When distributing, keep this in to verify the test script
-	# is working correctly, but limit to 2 (maaaaybe 3) so we
-	# don't slow the install process down too much.
-	$MAX_CHARS  = 2;
-	$ITERATIONS = 1000;
-	$LENGTH     = 190;
-	@ALL_CHARS  = (
-		qw{a b c f g m q r s t w x y z V W X 0 1 8 9},
-		';', '[', ']', '{', '}', '(', ')', '=', '?', '|', '+', '<',
-		'>', '.', '!', '~', '^', '*', '$', '@', '&', ':', '%', ',',
-		'\\', '/', '_', ' ', "\n", "\t", '-',
-		 "'", '"', '`', '#', # Comment out to make parsing more intense
-		);
-	#my @ALL_CHARS = (
-	#	qw{a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H
-	#	I J K L M N O P Q R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9},
-	#	';', '[', ']', '{', '}', '(', ')', '=', '?', '|', '+', '<', '>', '.',
-	#	'!', '~', '^', '*', '$', '@', '&', ':', '%', '#', ',', "'", '"', '`',
-	#	'\\', '/', '_', ' ', "\n", "\t", '-',
-	#	);
+# When distributing, keep this in to verify the test script
+# is working correctly, but limit to 2 (maaaaybe 3) so we
+# don't slow the install process down too much.
+our ( $MAX_CHARS, $ITERATIONS, $LENGTH )  = ( 2, 1000, 190 );
+our @ALL_CHARS = (
+	qw{a b c f g m q r s t w x y z V W X 0 1 8 9},
+	';', '[', ']', '{', '}', '(', ')', '=', '?', '|', '+', '<',
+	'>', '.', '!', '~', '^', '*', '$', '@', '&', ':', '%', ',',
+	'\\', '/', '_', ' ', "\n", "\t", '-',
+	"'", '"', '`', '#', # Comment out to make parsing more intense
+);
 
-	# Cases known to have failed in the past.
-	@FAILURES = (
-		# Failed cases 3 chars or less
-		'!%:', '!%:',  '!%:',  '!%:',  '!*:', '!@:',  '%:',  '%:,',
-		'%:;', '*:',   '*:,',  '*::',  '*:;', '+%:',  '+*:', '+@:',
-		'-%:', '-*:',  '-@:',  ';%:',  ';*:', ';@:',  '@:',  '@:,',
-		'@::', '@:;',  '\%:',  '\&:',  '\*:', '\@:',  '~%:', '~*:',
-		'~@:', '(<',   '(<',   '=<',   'm(',  'm(',   'm<',  'm[',
-		'm{',  'q(',   'q<',   'q[',   'q{',  's(',   's<',  's[',
-		's{',  'y(',   'y<',   'y[',   'y{',  '$\'0', '009', '0bB',
-		'0xX', '009;', '0bB;', '0xX;', "<<'", '<<"',  '<<`', '&::',
-		'<<a', '<<V',  '<<s',  '<<y',  '<<_',
+# Cases known to have failed in the past.
+our @FAILURES = (
+	# Failed cases 3 chars or less
+	'!%:', '!%:',  '!%:',  '!%:',  '!*:', '!@:',  '%:',  '%:,',
+	'%:;', '*:',   '*:,',  '*::',  '*:;', '+%:',  '+*:', '+@:',
+	'-%:', '-*:',  '-@:',  ';%:',  ';*:', ';@:',  '@:',  '@:,',
+	'@::', '@:;',  '\%:',  '\&:',  '\*:', '\@:',  '~%:', '~*:',
+	'~@:', '(<',   '(<',   '=<',   'm(',  'm(',   'm<',  'm[',
+	'm{',  'q(',   'q<',   'q[',   'q{',  's(',   's<',  's[',
+	's{',  'y(',   'y<',   'y[',   'y{',  '$\'0', '009', '0bB',
+	'0xX', '009;', '0bB;', '0xX;', "<<'", '<<"',  '<<`', '&::',
+	'<<a', '<<V',  '<<s',  '<<y',  '<<_',
 
-		# Failed cases 4 chars long.
-		# This isn't the complete set, as they tend to fail in groups
-		# of 50 or so, but I've used a representative sample.
-		'm;;_', 'm[]_', 'm]]_', 'm{}_', 'm}}_', 'm--_', 's[]a', 's[]b',
-		's[]0', 's[];', 's[]]', 's[]=', 's[].', 's[]_', 's{}]', 's{}?',
-		's<>s', 's<>-',
-		'*::0', '*::1', '*:::', '*::\'', '$::0',  '$:::', '$::\'',
-		'@::0', '@::1', '@:::', '&::0',  '&::\'', '%:::', '%::\'',
+	# Failed cases 4 chars long.
+	# This isn't the complete set, as they tend to fail in groups
+	# of 50 or so, but I've used a representative sample.
+	'm;;_', 'm[]_', 'm]]_', 'm{}_', 'm}}_', 'm--_', 's[]a', 's[]b',
+	's[]0', 's[];', 's[]]', 's[]=', 's[].', 's[]_', 's{}]', 's{}?',
+	's<>s', 's<>-',
+	'*::0', '*::1', '*:::', '*::\'', '$::0',  '$:::', '$::\'',
+	'@::0', '@::1', '@:::', '&::0',  '&::\'', '%:::', '%::\'',
 
-		# More-specific single cases thrown up during the heavy testing
-		'$:::z', '*:::z', "\\\@::'9:!", "} mz}~<<ts", "<\@<<q-r8\n/",
-		"W<<s`[\n(", "X<<f+X;g(<~\" \n1\n*", "c<<t* 9\ns\n~^{s ",
-		"<<V=-<<Wt", "[<<g/.<<r>\nV",
-		"( {8",
-	);
-}
+	# More-specific single cases thrown up during the heavy testing
+	'$:::z', '*:::z', "\\\@::'9:!", "} mz}~<<ts", "<\@<<q-r8\n/",
+	"W<<s`[\n(", "X<<f+X;g(<~\" \n1\n*", "c<<t* 9\ns\n~^{s ",
+	"<<V=-<<Wt", "[<<g/.<<r>\nV",
+	"( {8",
+);
 
-use Test::More tests => ($MAX_CHARS + $ITERATIONS + @FAILURES + ($ENV{AUTHOR_TESTING} ? 1 : 0));
+plan tests => ($MAX_CHARS + $ITERATIONS + @FAILURES + ($ENV{AUTHOR_TESTING} ? 1 : 0));
 
 
 

--- a/t/lib/Helper.pm
+++ b/t/lib/Helper.pm
@@ -1,10 +1,13 @@
 package Helper;
 
-use base 'Exporter';
+use strict;
+use warnings;
+use Exporter ();
 
 our $VERSION = '1.236';
 
-@EXPORT_OK = qw( check_with );
+our @ISA = "Exporter";
+our @EXPORT_OK = qw( check_with );
 
 sub check_with {
     my ( $code, $checker ) = @_;

--- a/t/lib/PPI/Test.pm
+++ b/t/lib/PPI/Test.pm
@@ -5,12 +5,11 @@ use strict;
 
 use File::Spec::Functions ();
 
-use vars qw{$VERSION @ISA @EXPORT_OK %EXPORT_TAGS};
-BEGIN {
-	$VERSION = '1.236';
-	@ISA = 'Exporter';
-	@EXPORT_OK = qw( find_files quotable pause );
-}
+our $VERSION = '1.236';
+
+our @ISA = 'Exporter';
+our @EXPORT_OK = qw( find_files quotable pause );
+our %EXPORT_TAGS;
 
 
 # Find file names in named t/data dirs

--- a/t/lib/PPI/Test/Object.pm
+++ b/t/lib/PPI/Test/Object.pm
@@ -3,7 +3,7 @@ package PPI::Test::Object;
 use warnings;
 use strict;
 
-use List::MoreUtils 'any';
+use List::Util 1.33 'any';
 use Params::Util qw{_INSTANCE};
 use PPI::Dumper;
 use Test::More;

--- a/t/lib/PPI/Test/Object.pm
+++ b/t/lib/PPI/Test/Object.pm
@@ -9,10 +9,7 @@ use PPI::Dumper;
 use Test::More;
 use Test::Object;
 
-use vars qw{$VERSION};
-BEGIN {
-	$VERSION = '1.236';
-}
+our $VERSION = '1.236';
 
 
 

--- a/t/lib/PPI/Test/Run.pm
+++ b/t/lib/PPI/Test/Run.pm
@@ -9,10 +9,7 @@ use Test::Object;
 use lib 't/lib';
 use PPI::Test::Object;
 
-use vars qw{$VERSION};
-BEGIN {
-	$VERSION = '1.236';
-}
+our $VERSION = '1.236';
 
 
 #####################################################################

--- a/t/lib/PPI/Test/pragmas.pm
+++ b/t/lib/PPI/Test/pragmas.pm
@@ -20,10 +20,7 @@ use warnings;
 use Test::More 0.88;
 use if $ENV{AUTHOR_TESTING}, 'Test::Warnings', ':no_end_test';
 
-use vars qw{$VERSION};
-BEGIN {
-	$VERSION = '1.236';
-}
+our $VERSION = '1.236';
 
 BEGIN {
 	select STDERR;  ## no critic ( InputOutput::ProhibitOneArgSelect )

--- a/t/ppi_statement_include.t
+++ b/t/ppi_statement_include.t
@@ -7,6 +7,7 @@ use PPI::Test::pragmas;
 use Test::More tests => 2065 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
+use PPI::Singletons '%KEYWORDS';
 
 
 TYPE: {
@@ -246,7 +247,7 @@ KEYWORDS_AS_MODULE_NAMES: {
 		'version',
 		# Keywords must parse as Word and not influence lexing
 		# of subsequent curly braces.
-		keys %PPI::Token::Word::KEYWORDS,
+		keys %KEYWORDS,
 		# Other weird and/or special words, just in case
 		'__PACKAGE__',
 		'__FILE__',

--- a/t/ppi_statement_package.t
+++ b/t/ppi_statement_package.t
@@ -7,6 +7,7 @@ use PPI::Test::pragmas;
 use Test::More tests => 2506 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
+use PPI::Singletons '%KEYWORDS';
 
 
 HASH_CONSTRUCTORS_DONT_CONTAIN_PACKAGES_RT52259: {
@@ -69,7 +70,7 @@ PERL_5_12_SYNTAX: {
 		'Foo',
 		# Keywords must parse as Word and not influence lexing
 		# of subsequent curly braces.
-		keys %PPI::Token::Word::KEYWORDS,
+		keys %KEYWORDS,
 		# regression: misparsed as version string
 		'v10',
 		# regression GitHub #122: 'x' parsed as x operator

--- a/t/ppi_statement_sub.t
+++ b/t/ppi_statement_sub.t
@@ -7,6 +7,7 @@ use PPI::Test::pragmas;
 use Test::More tests => 1208 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
+use PPI::Singletons '%KEYWORDS';
 
 NAME: {
 	for my $test (
@@ -178,7 +179,7 @@ KEYWORDS_AS_SUB_NAMES: {
 		'foo',
 		# Keywords must parse as Word and not influence lexing
 		# of subsequent curly braces.
-		keys %PPI::Token::Word::KEYWORDS,
+		keys %KEYWORDS,
 		# regression: misparsed as version string
 		'v10',
 		# Other weird and/or special words, just in case

--- a/t/ppi_token_number_version.t
+++ b/t/ppi_token_number_version.t
@@ -7,6 +7,7 @@ use PPI::Test::pragmas;
 use Test::More tests => 735 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
+use PPI::Singletons qw' %OPERATOR %QUOTELIKE %KEYWORDS ';
 
 
 LITERAL: {
@@ -37,7 +38,7 @@ VSTRING_ENDS_CORRECTLY: {
 			} (
 				'x3', # not fooled by faux x operator with operand
 				'e10', # not fooled by faux scientific notation
-				keys %PPI::Token::Word::KEYWORDS,
+				keys %KEYWORDS,
 			),
 		),
 		(
@@ -51,7 +52,7 @@ VSTRING_ENDS_CORRECTLY: {
 					],
 				},
 			} (
-				keys %PPI::Token::Word::KEYWORDS,
+				keys %KEYWORDS,
 			),
 		),
 		(
@@ -65,7 +66,7 @@ VSTRING_ENDS_CORRECTLY: {
 					],
 				},
 			} (
-				keys %PPI::Token::Word::KEYWORDS,
+				keys %KEYWORDS,
 			),
 		),
 		{
@@ -97,8 +98,8 @@ VSTRING_ENDS_CORRECTLY: {
 
 sub get_class {
 	my ( $t ) = @_;
-	my $ql = $PPI::Token::Word::QUOTELIKE{$t};
+	my $ql = $QUOTELIKE{$t};
 	return "PPI::Token::$ql" if $ql;
-	return 'PPI::Token::Operator' if $PPI::Token::Word::OPERATOR{$t};
+	return 'PPI::Token::Operator' if $OPERATOR{$t};
 	return 'PPI::Token::Word';
 }

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -7,7 +7,7 @@ use PPI::Test::pragmas;
 use Test::More tests => 1146 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
-
+use PPI::Singletons qw' %OPERATOR %KEYWORDS ';
 
 FIND_ONE_OP: {
 	my $source = '$a = .987;';
@@ -25,7 +25,7 @@ FIND_ONE_OP: {
 
 
 PARSE_ALL_OPERATORS: {
-	foreach my $op ( sort keys %PPI::Token::Operator::OPERATOR ) {
+	foreach my $op ( sort keys %OPERATOR ) {
 		my $source = $op eq '<>' ? '<>;' : "\$foo $op 2;";
 		my $doc = PPI::Document->new( \$source );
 		isa_ok( $doc, 'PPI::Document', "operator $op parsed '$source'" );
@@ -492,7 +492,7 @@ OPERATOR_X: {
 	# which '$obj->x86_convert()' was being parsed as an x
 	# operator.
 	my %operators = (
-		%PPI::Token::Operator::OPERATOR,
+		%OPERATOR,
 		map { $_ => 1 } qw( -r -w -x -o -R -W -X -O -e -z -s -f -d -l -p -S -b -c -t -u -g -k -T -B -M -A -C )
 	);
 	# Don't try to test operators for which PPI currently (1.215)
@@ -640,7 +640,7 @@ OPERATOR_FAT_COMMA: {
 				'PPI::Token::Operator' => '=>',
 				'PPI::Token::Number' => '2',
 			]
-		} } keys %PPI::Token::Word::KEYWORDS ),
+		} } keys %KEYWORDS ),
 		( map { {
 			desc=>$_,
 			code=>"($_=>2)",
@@ -653,7 +653,7 @@ OPERATOR_FAT_COMMA: {
 				'PPI::Token::Number' => '2',
 				'PPI::Token::Structure' => ')',
 			]
-		} } keys %PPI::Token::Word::KEYWORDS ),
+		} } keys %KEYWORDS ),
 		( map { {
 			desc=>$_,
 			code=>"{$_=>2}",
@@ -666,7 +666,7 @@ OPERATOR_FAT_COMMA: {
 				'PPI::Token::Number' => '2',
 				'PPI::Token::Structure' => '}',
 			]
-		} } keys %PPI::Token::Word::KEYWORDS ),
+		} } keys %KEYWORDS ),
 	);
 
 	for my $test ( @tests ) {

--- a/t/ppi_token_operator.t
+++ b/t/ppi_token_operator.t
@@ -4,7 +4,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 1146 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 1174 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 use PPI::Singletons qw' %OPERATOR %KEYWORDS ';
@@ -688,3 +688,45 @@ OPERATOR_FAT_COMMA: {
 	}
 }
 
+OPERATORS_PLUS_MINUS: {
+    my @operands = (
+         '1',   '2',
+         '1',  '(2)',
+        '(1)', '(2)'
+    );
+
+    for my $op (qw/- +/) {
+        for ( my $i = 0; $i < @operands; $i += 2 ) {
+            my ( $a, $b ) = @operands[ $i, $i + 1 ];
+            my $code = "${a}${op}${b}";
+            my $doc  = PPI::Document->new( \$code );
+            isa_ok( $doc, 'PPI::Document', "parsed '$code'" );
+            my $ops = $doc->find('Token::Operator');
+            is( ref $ops, 'ARRAY', "found operator $op" );
+            is( @$ops, 1, "operator $op found exactly once" );
+            is( $ops->[0]->content(), $op, "operator $op text matches" );
+        }
+    }
+
+    # Add "'(1)', '2'" into operands once TODO is resolved.
+    {
+        my ( $a, $b ) = ( '(1)', '2' );
+        my $op = '+';
+        my $code = "${a}${op}${b}";
+        my $doc  = PPI::Document->new( \$code );
+        isa_ok( $doc, 'PPI::Document', "parsed '$code'" );
+        my $ops = $doc->find('Token::Operator');
+        is( ref $ops, 'ARRAY', "found operator $op" );
+    }
+
+    TODO: {
+        local $TODO = "(1)-2 not parsed correctly";
+        my ( $a, $b ) = ( '(1)', '2' );
+        my $op = '-';
+        my $code = "${a}${op}${b}";
+        my $doc  = PPI::Document->new( \$code );
+        isa_ok( $doc, 'PPI::Document', "parsed '$code'" );
+        my $ops = $doc->find('Token::Operator');
+        is( ref $ops, 'ARRAY', "found operator $op" );
+    }
+}


### PR DESCRIPTION
In code '(1)-1' is -1 parsed as a number rather than operator and 1.
This commit adds a TODO test that covers this scenario and more other
tests covering correct behaviour for '(1)+1' etc.

This provides test coverage for #43 

Done as part of CPAN pull request challenge.