### PR TITLE
Parse list-embedded curlies as hash constructors

### DIFF
--- a/lib/PPI/Lexer.pm
+++ b/lib/PPI/Lexer.pm
@@ -1170,17 +1170,20 @@ sub _curly {
 	### FIXME This is possibly a bad choice, but will have to do for now.
 	return 'PPI::Structure::Block' if $Element;
 
-	# Special case: Are we the param of a core function
-	# i.e. map({ $_ => 1 } @foo)
 	if (
 		$Parent->isa('PPI::Statement')
 		and
 		_INSTANCE($Parent->parent, 'PPI::Structure::List')
 	) {
+		# Special case: Are we the param of a core function
+		# i.e. map({ $_ => 1 } @foo)
 		my $function = $Parent->parent->parent->schild(-2);
-		if ( $function and $function->content =~ /^(?:map|grep|sort)$/ ) {
+		if ( $function and $function->content =~ /^(?:map|grep|sort|eval)$/ ) {
 			return 'PPI::Structure::Block';
 		}
+
+		# Other cases of list-embedded curlies are constructors
+		return 'PPI::Structure::Constructor';
 	}
 
 	# We need to scan ahead.

--- a/t/05_lexer.t
+++ b/t/05_lexer.t
@@ -5,7 +5,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 218 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 236 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use File::Spec::Functions ':ALL';
 use PPI::Lexer;

--- a/t/data/05_lexer/13_hashref_in_parens.code
+++ b/t/data/05_lexer/13_hashref_in_parens.code
@@ -1,0 +1,1 @@
+$hashref = ({ %base_args, arg => $mod_value });

--- a/t/data/05_lexer/13_hashref_in_parens.dump
+++ b/t/data/05_lexer/13_hashref_in_parens.dump
@@ -1,0 +1,22 @@
+PPI::Document
+  PPI::Statement
+    PPI::Token::Symbol  	'$hashref'
+    PPI::Token::Whitespace  	' '
+    PPI::Token::Operator  	'='
+    PPI::Token::Whitespace  	' '
+    PPI::Structure::List  	( ... )
+      PPI::Statement
+        PPI::Structure::Constructor  	{ ... }
+          PPI::Token::Whitespace  	' '
+          PPI::Statement
+            PPI::Token::Symbol  	'%base_args'
+            PPI::Token::Operator  	','
+            PPI::Token::Whitespace  	' '
+            PPI::Token::Word  	'arg'
+            PPI::Token::Whitespace  	' '
+            PPI::Token::Operator  	'=>'
+            PPI::Token::Whitespace  	' '
+            PPI::Token::Symbol  	'$mod_value'
+          PPI::Token::Whitespace  	' '
+    PPI::Token::Structure  	';'
+  PPI::Token::Whitespace  	'\n'

--- a/t/data/08_regression/24_compound.dump
+++ b/t/data/08_regression/24_compound.dump
@@ -2,7 +2,7 @@ PPI::Document
   PPI::Statement
     PPI::Token::Word  	'eval'
     PPI::Structure::List  	( ... )
-      PPI::Statement::Compound
+      PPI::Statement
         PPI::Token::Whitespace  	' '
         PPI::Structure::Block  	{ ... }
           PPI::Statement


### PR DESCRIPTION
This change fixes parsing of constructs like these:
```
foo({ %hash, key => 1 })
$ref = ({ %hash, key => 1 })
```
which were previously erroneously recognized as compound statements. It also fixes the original compound regression test, added in 0f74bdc1aa05fd5732c85d44e315046568e65641 as a failing test (since eval is not a compound statement as per [perlsyn](https://metacpan.org/pod/perlsyn#Simple-Statements)).

The logic is based on the assumption that curly braces inside parentheses are constructors unless they are arguments to one of the block built-ins (map, grep, sort and eval). Subs with the & prototype do not compile with parentheses and neither do loose blocks:
```
$ perl -e 'sub foo (&) { $_[0]->() } foo({ print "Hello" })'
Type of arg 1 to main::foo must be block or sub {} (not anonymous hash ({})) at -e line 1, near "})"
Execution of -e aborted due to compilation errors.
```
```
$ perl -e '({ print "Hello"; })'
syntax error at -e line 1, near "; }"
Execution of -e aborted due to compilation errors.
```

This also fixes issue #68.