### PR TITLE
Support key-value and index-value slices in PPI::Token::Symbol symbol method

### DIFF
--- a/lib/PPI/Token/Symbol.pm
+++ b/lib/PPI/Token/Symbol.pm
@@ -80,7 +80,7 @@ Returns the symbol as a string.
 
 =cut
 
-my %cast_which_trumps_braces = map { $_ => 1 } qw{ $ @ };
+my %cast_which_trumps_braces = map { $_ => 1 } qw{ $ @ % };
 
 sub symbol {
 	my $self   = shift;
@@ -88,7 +88,6 @@ sub symbol {
 
 	# Immediately return the cases where it can't be anything else
 	my $type = substr( $symbol, 0, 1 );
-	return $symbol if $type eq '%';
 	return $symbol if $type eq '&';
 
 	# Unless the next significant Element is a structure, it's correct.
@@ -112,6 +111,9 @@ sub symbol {
 
 	} elsif ( $type eq '@' ) {
 		substr( $symbol, 0, 1, '%' ) if $braces eq '{}';
+
+	} elsif ( $type eq '%' ) {
+		substr( $symbol, 0, 1, '@' ) if $braces eq '[]';
 
 	}
 

--- a/t/ppi_token_symbol.t
+++ b/t/ppi_token_symbol.t
@@ -4,7 +4,7 @@
 
 use lib 't/lib';
 use PPI::Test::pragmas;
-use Test::More tests => 128 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+use Test::More tests => 191 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
 
 use PPI;
 
@@ -26,14 +26,24 @@ TOKEN_FROM_PARSE: {
 	parse_and_test( '@x{0}',   { content => '@x',   canonical => '@x',       raw_type => '@', symbol_type => '%', symbol => '%x' } );
 	parse_and_test( '@::x',    { content => '@::x', canonical => '@main::x', raw_type => '@', symbol_type => '@', symbol => '@main::x' } );
 
-	parse_and_test( '%x',   { content => '%x',   canonical => '%x',       raw_type => '%', symbol_type => '%', symbol => '%x' } );
-	parse_and_test( '%::x', { content => '%::x', canonical => '%main::x', raw_type => '%', symbol_type => '%', symbol => '%main::x' } );
+	parse_and_test( '%x',      { content => '%x',   canonical => '%x',       raw_type => '%', symbol_type => '%', symbol => '%x' } );
+	parse_and_test( '%x[0]',   { content => '%x',   canonical => '%x',       raw_type => '%', symbol_type => '@', symbol => '@x' } );
+	parse_and_test( '%x[0,1]', { content => '%x',   canonical => '%x',       raw_type => '%', symbol_type => '@', symbol => '@x' } );
+	parse_and_test( '%x{0}',   { content => '%x',   canonical => '%x',       raw_type => '%', symbol_type => '%', symbol => '%x' } );
+	parse_and_test( '%::x',    { content => '%::x', canonical => '%main::x', raw_type => '%', symbol_type => '%', symbol => '%main::x' } );
 
 	parse_and_test( '&x',   { content => '&x',   canonical => '&x',       raw_type => '&', symbol_type => '&', symbol => '&x' } );
 	parse_and_test( '&::x', { content => '&::x', canonical => '&main::x', raw_type => '&', symbol_type => '&', symbol => '&main::x' } );
 
 	parse_and_test( '*x',   { content => '*x',   canonical => '*x',       raw_type => '*', symbol_type => '*', symbol => '*x' } );
 	parse_and_test( '*::x', { content => '*::x', canonical => '*main::x', raw_type => '*', symbol_type => '*', symbol => '*main::x' } );
+
+	parse_and_test( '$$x[0]', { content => '$x', canonical => '$x', raw_type => '$', symbol_type => '$', symbol => '$x' } );
+	parse_and_test( '@$x[0]', { content => '$x', canonical => '$x', raw_type => '$', symbol_type => '$', symbol => '$x' } );
+	parse_and_test( '%$x[0]', { content => '$x', canonical => '$x', raw_type => '$', symbol_type => '$', symbol => '$x' } );
+	parse_and_test( '$$x{0}', { content => '$x', canonical => '$x', raw_type => '$', symbol_type => '$', symbol => '$x' } );
+	parse_and_test( '@$x{0}', { content => '$x', canonical => '$x', raw_type => '$', symbol_type => '$', symbol => '$x' } );
+	parse_and_test( '%$x{0}', { content => '$x', canonical => '$x', raw_type => '$', symbol_type => '$', symbol => '$x' } );
 }
 
 


### PR DESCRIPTION
The key-value and index-value slice operations added in Perl 5.20 mean that the % symbol also may not indicate the true symbol type. Also added tests for the casted scalar refs to ensure they still parse as scalars.