### PR TITLE
Simplify `heredoc`

### DIFF
--- a/lib/PPI/Token/HereDoc.pm
+++ b/lib/PPI/Token/HereDoc.pm
@@ -111,11 +111,7 @@ the here-doc, B<excluding> the terminator line.
 
 =cut
 
-sub heredoc {
-	wantarray
-		? @{shift->{_heredoc}}
-		: scalar @{shift->{_heredoc}};
-}
+sub heredoc { @{shift->{_heredoc}} }
 
 =pod
 


### PR DESCRIPTION
Useless use of `wantarray`: the context is already propagated to the single statement, so there is no need for an explicit `scalar`.