### PR TITLE
Add GitHub workflows

### DIFF
--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -1,0 +1,167 @@
+---
+name: dzil build and test
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+  schedule:
+    - cron: "15 4 * * 0"
+
+jobs:
+  build-job:
+    name: Build distribution
+    runs-on: ubuntu-20.04
+    container:
+      image: perldocker/perl-tester:5.32
+    steps:
+      - uses: actions/checkout@v2
+      - name: install authordeps
+        run: dzil authordeps --missing | cpanm
+      - name: install deps
+        run: dzil listdeps --missing --author | cpanm
+      - name: Run Tests
+        env:
+          AUTHOR_TESTING: 0
+          AUTOMATED_TESTING: 1
+          EXTENDED_TESTING: 1
+          RELEASE_TESTING: 0
+        run: auto-build-and-test-dist
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build_dir
+          path: build_dir
+  coverage-job:
+    needs: build-job
+    runs-on: ubuntu-20.04
+    container:
+      image: perldocker/perl-tester:5.32
+    steps:
+      - uses: actions/checkout@v2 # codecov wants to be inside a Git repository
+      - uses: actions/download-artifact@v2
+        with:
+          name: build_dir
+          path: .
+      - name: install authordeps
+        run: dzil authordeps --missing | cpanm
+      - name: install deps
+        run: dzil listdeps --missing --author | cpanm
+      - name: Install deps and test
+        run: cpan-install-dist-deps && test-dist
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+  ubuntu-test-job:
+    needs: build-job
+    runs-on: "ubuntu-20.04"
+    strategy:
+      fail-fast: true
+      matrix:
+        perl-version:
+          - "5.8"
+          - "5.10"
+          - "5.12"
+          - "5.14"
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+          - "5.32"
+    name: Perl ${{ matrix.perl-version }} on ubuntu-20.04
+    steps:
+      - name: set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: build_dir
+          path: .
+      - name: install deps using cpanm
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          args: " --installdeps ."
+      - name: Run tests
+        run: prove -lr t
+        env:
+          AUTHOR_TESTING: 0
+          RELEASE_TESTING: 0
+  macos-test-job:
+    needs: ubuntu-test-job
+    runs-on: "macos-latest"
+    strategy:
+      fail-fast: true
+      matrix:
+        perl-version:
+          - "5.8"
+          - "5.10"
+          - "5.12"
+          - "5.14"
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+          - "5.32"
+    name: perl ${{ matrix.perl-version }} on macos-latest
+    steps:
+      - name: set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: build_dir
+          path: .
+      - name: install deps using cpanm
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          args: " --installdeps ."
+      - run: prove -lr t
+        env:
+          AUTHOR_TESTING: 0
+          RELEASE_TESTING: 0
+  windows-test-job:
+    needs: ubuntu-test-job
+    runs-on: "windows-latest"
+    strategy:
+      fail-fast: true
+      matrix:
+        perl-version:
+          - "5.14"
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+    name: perl ${{ matrix.perl-version }} on windows-latest
+    steps:
+      - name: set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+          distribution: strawberry # this option only used on windows
+      - uses: actions/download-artifact@v2
+        with:
+          name: build_dir
+          path: .
+      - name: install deps using cpanm
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          args: " --installdeps ."
+      - run: prove -lr t
+        env:
+          AUTHOR_TESTING: 0
+          RELEASE_TESTING: 0


### PR DESCRIPTION
This uses codecov.io rather than Coveralls. To enable codecov.io on a repo, you
need to log in to codecov.io and get a token which would be added to the
secrets for this repository as CODECOV_TOKEN. Anyone with the correct perms on
the repository should be able to do this. Not sure if this is also possible
with Coveralls.

I'm happy to remove or tweak the coverage reporting as requested. With the way
things are going with Travis, it seems good to do this sooner rather than
later.